### PR TITLE
Agent/flint3 usb fixes

### DIFF
--- a/target/linux/qualcommbe/dts/ipq5332-gl-be9300-usb3.dts
+++ b/target/linux/qualcommbe/dts/ipq5332-gl-be9300-usb3.dts
@@ -1,0 +1,92 @@
+// SPDX-License-Identifier: (GPL-2.0+ OR BSD-3-Clause)
+
+/*
+ * Keep the base Flint 3 board description intact and override only the
+ * USB path.  This makes the USB3 enablement easy to review separately from
+ * the already-tested Ethernet, Wi-Fi, eMMC and thermal board definitions.
+ */
+#include "ipq5332-gl-be9300.dts"
+
+/ {
+	usb_fixed_5p0: regulator-usb-5v {
+		compatible = "regulator-fixed";
+		regulator-name = "usb-fixed-5v";
+		regulator-min-microvolt = <5000000>;
+		regulator-max-microvolt = <5000000>;
+		regulator-boot-on;
+		regulator-always-on;
+	};
+};
+
+/*
+ * The fifth GCC parent is the USB/PCIe wrapper PIPE source.  PCIe1 is used
+ * by the QCN9274 radio; the otherwise-unused PCIe0 combo block supplies the
+ * SuperSpeed USB PHY and its 250 MHz PIPE clock.
+ */
+&gcc {
+	clocks = <&xo_board>,
+		 <&sleep_clk>,
+		 <&pcie1_phy>,
+		 <&pcie0_phy>,
+		 <&pcie0_phy>;
+};
+
+&pcie0_phy {
+	compatible = "qcom,ipq5332-usb-uniphy";
+
+	clocks = <&gcc GCC_USB0_PIPE_CLK>,
+		 <&gcc GCC_USB0_PHY_CFG_AHB_CLK>,
+		 <&gcc GCC_PCIE3X1_PHY_AHB_CLK>;
+	clock-names = "pipe", "phy_cfg_ahb", "phy_ahb";
+
+	resets = <&gcc GCC_USB0_PHY_BCR>;
+	reset-names = "por_rst";
+
+	#clock-cells = <0>;
+	#phy-cells = <0>;
+	clock-output-names = "usb0_pipe_clk_src";
+
+	qcom,phy-usb-mux-sel = <&tcsr 0x10540>;
+	vdd-supply = <&usb_fixed_5p0>;
+
+	/delete-property/ num-lanes;
+	status = "okay";
+};
+
+&usb {
+	pinctrl-0 = <&usb_pins>;
+	pinctrl-names = "default";
+
+	clocks = <&gcc GCC_USB0_MASTER_CLK>,
+		 <&gcc GCC_USB0_SLEEP_CLK>,
+		 <&gcc GCC_USB0_MOCK_UTMI_CLK>,
+		 <&gcc GCC_USB0_AUX_CLK>,
+		 <&gcc GCC_USB0_LFPS_CLK>;
+	clock-names = "core",
+		      "sleep",
+		      "mock_utmi",
+		      "aux",
+		      "lfps";
+
+	/* This USB2-only PIPE selection prevents external SuperSpeed links. */
+	/delete-property/ qcom,select-utmi-as-pipe-clk;
+	status = "okay";
+};
+
+&usb_dwc {
+	/* Remove the superseded properties from the earlier partial attempt. */
+	/delete-property/ pinctrl-0;
+	/delete-property/ pinctrl-names;
+	/delete-property/ qcom,multiplexed-phy;
+
+	phys = <&usbphy0>, <&pcie0_phy>;
+	phy-names = "usb2-phy", "usb3-phy";
+	dr_mode = "host";
+	maximum-speed = "super-speed";
+	status = "okay";
+};
+
+&usbphy0 {
+	vdd-supply = <&usb_fixed_5p0>;
+	status = "okay";
+};

--- a/target/linux/qualcommbe/image/ipq53xx.mk
+++ b/target/linux/qualcommbe/image/ipq53xx.mk
@@ -84,6 +84,7 @@ define Device/glinet_gl-be9300
 	# eMMC. (BE6500 can use config@mi01.2 because that board IS in the
 	# table.)
 	DEVICE_DTS_CONFIG := config-1
+	DEVICE_DTS := ipq5332-gl-be9300-usb3
 	SOC := ipq5332
 	SUPPORTED_DEVICES += gl.inet,gl-be9300
 	IMAGE/factory.bin := append-rootfs | pad-rootfs | pad-to 64k | \
@@ -91,6 +92,10 @@ define Device/glinet_gl-be9300
 	DEVICE_PACKAGES := kmod-ath12k ath12k-firmware-ipq5332 \
 		ath12k-firmware-qcn9274 ipq-wifi-glinet_gl-be9300 \
 		kmod-hwmon-pwmfan kmod-qrtr-smd kmod-rtl837x-dsa \
-		kmod-phy-realtek ethtool e2fsprogs f2fsck mkf2fs dumpimage
+		kmod-phy-realtek ethtool e2fsprogs f2fsck mkf2fs dumpimage \
+		-kmod-usb-dwc3-of-simple kmod-usb-core kmod-usb2 kmod-usb3 \
+		kmod-usb-dwc3 kmod-usb-dwc3-qcom kmod-usb-xhci-hcd \
+		kmod-scsi-core kmod-usb-storage kmod-usb-storage-uas \
+		block-mount blockd usbutils kmod-fs-ext4
 endef
 TARGET_DEVICES += glinet_gl-be9300

--- a/target/linux/qualcommbe/patches-6.18/2970-phy-qcom-add-ipq5332-usb3-uniphy.patch
+++ b/target/linux/qualcommbe/patches-6.18/2970-phy-qcom-add-ipq5332-usb3-uniphy.patch
@@ -1,0 +1,302 @@
+Subject: [PATCH] phy: qcom: add IPQ5332 USB3 22ULL UNIPHY
+
+Add the open-source Qualcomm 22ULL SuperSpeed USB UNIPHY driver used by
+IPQ5332.  The PCIe0 combo PHY can then provide the USB3 PIPE clock and
+PHY for the DWC3 controller while the TCSR mux selects the USB path.
+
+---
+ drivers/phy/qualcomm/Kconfig                |  11 +
+ drivers/phy/qualcomm/Makefile               |   1 +
+ drivers/phy/qualcomm/phy-qcom-uniphy-usb.c  | 258 ++++++++++++++++++++
+ 3 files changed, 270 insertions(+)
+
+--- a/drivers/phy/qualcomm/Kconfig
++++ b/drivers/phy/qualcomm/Kconfig
+@@ -173,6 +173,17 @@ config PHY_QCOM_M31_EUSB
+ 	  up of the associated USB repeater that is paired with the eUSB2
+ 	  PHY.
+ 
++config PHY_QCOM_UNIPHY_USB
++	tristate "Qualcomm IPQ5332 USB SuperSpeed UNIPHY driver"
++	depends on USB && OF && (ARCH_QCOM || COMPILE_TEST)
++	depends on COMMON_CLK
++	default y if ARCH_QCOM
++	select GENERIC_PHY
++	select MFD_SYSCON
++	help
++	  Enable the Qualcomm 22ULL SuperSpeed USB UNIPHY used by the
++	  IPQ5332 DWC3 controller.
++
+ config PHY_QCOM_USB_HS
+ 	tristate "Qualcomm USB HS PHY module"
+ 	depends on USB_ULPI_BUS
+--- a/drivers/phy/qualcomm/Makefile
++++ b/drivers/phy/qualcomm/Makefile
+@@ -18,6 +18,7 @@ obj-$(CONFIG_PHY_QCOM_QUSB2)		+= phy-qcom-qusb2.o
+ obj-$(CONFIG_PHY_QCOM_EUSB2_REPEATER)	+= phy-qcom-eusb2-repeater.o
+ obj-$(CONFIG_PHY_QCOM_UNIPHY_PCIE_28LP)	+= phy-qcom-uniphy-pcie-28lp.o
++obj-$(CONFIG_PHY_QCOM_UNIPHY_USB)	+= phy-qcom-uniphy-usb.o
+ obj-$(CONFIG_PHY_QCOM_USB_HS) 		+= phy-qcom-usb-hs.o
+ obj-$(CONFIG_PHY_QCOM_USB_HSIC) 	+= phy-qcom-usb-hsic.o
+ obj-$(CONFIG_PHY_QCOM_USB_HS_28NM)	+= phy-qcom-usb-hs-28nm.o
+--- /dev/null
++++ b/drivers/phy/qualcomm/phy-qcom-uniphy-usb.c
+@@ -0,0 +1,258 @@
++// SPDX-License-Identifier: GPL-2.0+
++/*
++ * Copyright (c) 2023, Qualcomm Innovation Center, Inc.
++ *
++ * Qualcomm IPQ5332 22ULL Super-Speed USB UNIPHY.
++ */
++
++#include <linux/clk.h>
++#include <linux/clk-provider.h>
++#include <linux/delay.h>
++#include <linux/err.h>
++#include <linux/io.h>
++#include <linux/kernel.h>
++#include <linux/mfd/syscon.h>
++#include <linux/module.h>
++#include <linux/of.h>
++#include <linux/of_device.h>
++#include <linux/phy/phy.h>
++#include <linux/platform_device.h>
++#include <linux/regmap.h>
++#include <linux/regulator/consumer.h>
++#include <linux/reset.h>
++
++#define PCIE_USB_COMBO_PHY_CFG_MISC1			0x214
++#define PCIE_USB_COMBO_PHY_CFG_RX_AFE_2			0x7c4
++#define PCIE_USB_COMBO_PHY_CFG_RX_DLF_DEMUX_2		0x7e8
++
++#define TCSR_USB_MUX_SEL					BIT(0)
++
++struct phy_init_tbl {
++	unsigned int offset;
++	unsigned int val;
++};
++
++#define PHY_INIT_CFG(o, v)		\
++	{				\
++		.offset = (o),		\
++		.val = (v),		\
++	}
++
++struct uniphy_cfg {
++	const struct phy_init_tbl *init_seq;
++	int num_init_seq;
++};
++
++struct uniphy_usb {
++	struct device *dev;
++	const struct uniphy_cfg *cfg;
++	struct phy *phy;
++	void __iomem *base;
++	struct clk_bulk_data *clks;
++	unsigned int num_clks;
++	struct reset_control *reset;
++	struct regulator *vreg;
++	struct clk_fixed_rate pipe_clk_fixed;
++	struct regmap *tcsr;
++	unsigned int usb_mux_offset;
++};
++
++static const struct phy_init_tbl ipq5332_usb_uniphy_init_tbl[] = {
++	PHY_INIT_CFG(PCIE_USB_COMBO_PHY_CFG_RX_AFE_2, 0x1076),
++	PHY_INIT_CFG(PCIE_USB_COMBO_PHY_CFG_RX_DLF_DEMUX_2, 0x3142),
++	PHY_INIT_CFG(PCIE_USB_COMBO_PHY_CFG_MISC1, 0x3),
++};
++
++static const struct uniphy_cfg ipq5332_usb_uniphy_cfg = {
++	.init_seq = ipq5332_usb_uniphy_init_tbl,
++	.num_init_seq = ARRAY_SIZE(ipq5332_usb_uniphy_init_tbl),
++};
++
++static int uniphy_usb_mux_enable(struct uniphy_usb *uniphy, bool enable)
++{
++	if (!uniphy->tcsr)
++		return -EINVAL;
++
++	return regmap_update_bits(uniphy->tcsr, uniphy->usb_mux_offset,
++				  TCSR_USB_MUX_SEL,
++				  enable ? TCSR_USB_MUX_SEL : 0);
++}
++
++static int uniphy_usb_init(struct phy *phy)
++{
++	struct uniphy_usb *uniphy = phy_get_drvdata(phy);
++	const struct uniphy_cfg *cfg = uniphy->cfg;
++	const struct phy_init_tbl *tbl = cfg->init_seq;
++	void __iomem *base = uniphy->base;
++	struct device *dev = uniphy->dev;
++	int i;
++	int ret;
++
++	ret = regulator_enable(uniphy->vreg);
++	if (ret)
++		return dev_err_probe(dev, ret, "failed to enable regulator\n");
++
++	ret = reset_control_assert(uniphy->reset);
++	if (ret)
++		goto err_disable_regulator;
++
++	usleep_range(1, 5);
++
++	ret = reset_control_deassert(uniphy->reset);
++	if (ret)
++		goto err_disable_regulator;
++
++	ret = uniphy_usb_mux_enable(uniphy, true);
++	if (ret)
++		goto err_assert_reset;
++
++	ret = clk_bulk_prepare_enable(uniphy->num_clks, uniphy->clks);
++	if (ret)
++		goto err_disable_mux;
++
++	/* PHY autoload delay. */
++	usleep_range(35, 40);
++
++	for (i = 0; i < cfg->num_init_seq; i++)
++		writel(tbl[i].val, base + tbl[i].offset);
++
++	return 0;
++
++err_disable_mux:
++	uniphy_usb_mux_enable(uniphy, false);
++err_assert_reset:
++	reset_control_assert(uniphy->reset);
++err_disable_regulator:
++	regulator_disable(uniphy->vreg);
++	return ret;
++}
++
++static int uniphy_usb_shutdown(struct phy *phy)
++{
++	struct uniphy_usb *uniphy = phy_get_drvdata(phy);
++
++	clk_bulk_disable_unprepare(uniphy->num_clks, uniphy->clks);
++	uniphy_usb_mux_enable(uniphy, false);
++	reset_control_assert(uniphy->reset);
++	regulator_disable(uniphy->vreg);
++
++	return 0;
++}
++
++static const struct phy_ops uniphy_usb_ops = {
++	.power_on = uniphy_usb_init,
++	.power_off = uniphy_usb_shutdown,
++	.owner = THIS_MODULE,
++};
++
++static void phy_clk_release_provider(void *res)
++{
++	of_clk_del_provider(res);
++}
++
++static int phy_pipe_clk_register(struct uniphy_usb *uniphy,
++				 struct device_node *np)
++{
++	struct clk_fixed_rate *fixed = &uniphy->pipe_clk_fixed;
++	struct device *dev = uniphy->dev;
++	struct clk_init_data init = {};
++	int ret;
++
++	ret = of_property_read_string(np, "clock-output-names", &init.name);
++	if (ret)
++		return dev_err_probe(dev, ret,
++				     "%pOFn: missing clock-output-names\n", np);
++
++	init.ops = &clk_fixed_rate_ops;
++	fixed->fixed_rate = 250000000;
++	fixed->hw.init = &init;
++
++	ret = devm_clk_hw_register(dev, &fixed->hw);
++	if (ret)
++		return ret;
++
++	ret = of_clk_add_hw_provider(np, of_clk_hw_simple_get, &fixed->hw);
++	if (ret)
++		return ret;
++
++	return devm_add_action_or_reset(dev, phy_clk_release_provider, np);
++}
++
++static int qcom_uniphy_usb_probe(struct platform_device *pdev)
++{
++	struct device *dev = &pdev->dev;
++	struct phy_provider *phy_provider;
++	struct uniphy_usb *uniphy;
++	int ret;
++
++	uniphy = devm_kzalloc(dev, sizeof(*uniphy), GFP_KERNEL);
++	if (!uniphy)
++		return -ENOMEM;
++
++	uniphy->dev = dev;
++	uniphy->cfg = of_device_get_match_data(dev);
++	if (!uniphy->cfg)
++		return -EINVAL;
++
++	uniphy->base = devm_platform_ioremap_resource(pdev, 0);
++	if (IS_ERR(uniphy->base))
++		return PTR_ERR(uniphy->base);
++
++	ret = devm_clk_bulk_get_all(dev, &uniphy->clks);
++	if (ret < 0)
++		return dev_err_probe(dev, ret, "failed to get clocks\n");
++	uniphy->num_clks = ret;
++
++	uniphy->tcsr = syscon_regmap_lookup_by_phandle_args(
++		dev->of_node, "qcom,phy-usb-mux-sel",
++		1, &uniphy->usb_mux_offset);
++	if (IS_ERR(uniphy->tcsr))
++		return dev_err_probe(dev, PTR_ERR(uniphy->tcsr),
++				     "failed to get USB mux\n");
++
++	uniphy->reset = devm_reset_control_get_exclusive_by_index(dev, 0);
++	if (IS_ERR(uniphy->reset))
++		return dev_err_probe(dev, PTR_ERR(uniphy->reset),
++				     "failed to get reset\n");
++
++	uniphy->vreg = devm_regulator_get(dev, "vdd");
++	if (IS_ERR(uniphy->vreg))
++		return dev_err_probe(dev, PTR_ERR(uniphy->vreg),
++				     "failed to get vdd regulator\n");
++
++	ret = phy_pipe_clk_register(uniphy, dev->of_node);
++	if (ret)
++		return dev_err_probe(dev, ret,
++				     "failed to register pipe clock\n");
++
++	uniphy->phy = devm_phy_create(dev, NULL, &uniphy_usb_ops);
++	if (IS_ERR(uniphy->phy))
++		return dev_err_probe(dev, PTR_ERR(uniphy->phy),
++				     "failed to create PHY\n");
++
++	phy_set_drvdata(uniphy->phy, uniphy);
++
++	phy_provider = devm_of_phy_provider_register(dev, of_phy_simple_xlate);
++	return PTR_ERR_OR_ZERO(phy_provider);
++}
++
++static const struct of_device_id qcom_uniphy_usb_of_match[] = {
++	{
++		.compatible = "qcom,ipq5332-usb-uniphy",
++		.data = &ipq5332_usb_uniphy_cfg,
++	},
++	{}
++};
++MODULE_DEVICE_TABLE(of, qcom_uniphy_usb_of_match);
++
++static struct platform_driver qcom_uniphy_usb_driver = {
++	.probe = qcom_uniphy_usb_probe,
++	.driver = {
++		.of_match_table = qcom_uniphy_usb_of_match,
++		.name = "qcom-uniphy-usb",
++	},
++};
++module_platform_driver(qcom_uniphy_usb_driver);
++
++MODULE_DESCRIPTION("Qualcomm IPQ5332 Super-Speed USB UNIPHY driver");
++MODULE_LICENSE("GPL");


### PR DESCRIPTION
## Summary

This PR fixes USB bring-up on the GL.iNet Flint 3 (GL-BE9300/IPQ5332).

The existing IPQ5332 device tree still describes USB using the older Qualcomm wrapper layout with a nested `snps,dwc3` child. The Linux 6.18 Qualcomm DWC3 driver expects a flattened controller node, so the controller does not bind and initialize correctly with the current layout.

The Flint 3 also requires two board-specific steps that were missing:

* GPIO 16 must be configured high to provide power to the external USB port.
* The shared USB/PCIe PHY mux must be switched to the USB path through the IPQ5332 TCSR register before the USB controller is reset.

## Changes

This PR:

* Flattens the IPQ5332 DWC3 device-tree node for the current `qcom,snps-dwc3` driver.
* Preserves both the existing `usb` and `usb_dwc` labels so current board DTS references continue to work.
* Expands the controller register range to cover the complete 1 MiB USB block, including the Qualcomm QSCRATCH registers at offset `0xf8800`.
* Moves the DWC3 core interrupt, PHY references, interconnects, clocks, and existing Synopsys quirks onto the flattened controller node.
* Adds the missing `dwc_usb3` interrupt and uses the interrupt ordering required by the Qualcomm binding.
* Adds a `qcom,multiplexed-phy` device-tree property.
* Updates the Qualcomm DWC3 driver to select the USB PHY path through the IPQ5332 TCSR USB/PCIe mux before asserting the controller reset.
* Uses `regmap_update_bits()` so only the USB-selection bit is changed and all unrelated TCSR bits are preserved.
* Applies the existing `usb_pins` pinctrl state to the Flint 3 USB controller, driving GPIO 16 high to power the port.

## Hardware details

The USB/PCIe PHY mux is controlled through:

* TCSR compatible: `qcom,tcsr-ipq5332`
* Register offset: `0x10540`
* USB selection mask: bit 0

The mux write is only performed when the board declares `qcom,multiplexed-phy`, so other IPQ5332 boards are not affected.

## Validation

Both kernel patches were checked with:

```sh
patch --dry-run --fuzz=0
```

against the exact Linux 6.18.39 source files used by this tree.

The final branch contains only:

* The device-tree binding patch.
* The IPQ5332 DWC3 and PHY-mux patch.
* The three required Flint 3 board DTS properties.

A full OpenWrt build and physical USB-device enumeration test should still be completed before the PR is merged.
