### PR TITLE
rtl837x: fix DSA tagger documentation

### DIFF
--- a/package/kernel/rtl837x/README.md
+++ b/package/kernel/rtl837x/README.md
@@ -26,11 +26,17 @@ It builds the switch driver module:
 rtl837x_dsa.ko
 ```
 
-The driver also depends on the RTL 8-byte DSA tagger:
+The driver also builds and loads the standard 802.1Q DSA tagger:
 
 ```text
-tag_rtl8_4.ko
+tag_vsc73xx_8021q.ko
 ```
+
+The module name comes from the upstream DSA implementation used for the
+`VSC73XX_8021Q` tag protocol; the RTL837x driver reuses it as its
+`tag_8021q` transport. The proprietary RTL8_4/0x8899 CPU tag is intentionally
+not used because the IPQ5332 EDMA checksum parser must be able to parse past
+the CPU tag. Do not replace this dependency with `tag_rtl8_4.ko`.
 
 ## Device Tree
 


### PR DESCRIPTION
## Summary

The RTL837x README says that the driver depends on `tag_rtl8_4.ko`, but the
package Makefile selects and builds `tag_vsc73xx_8021q.ko` instead. The DSA
driver also returns `DSA_TAG_PROTO_VSC73XX_8021Q`.

Update the README to document the module that is actually packaged and explain
why the standard 802.1Q transport is intentional on IPQ5332.

## Why this is correct

The proposed text is derived directly from the current package and driver:

* `package/kernel/rtl837x/Makefile` selects
  `CONFIG_NET_DSA_TAG_VSC73XX_8021Q` and packages
  `tag_vsc73xx_8021q.ko`.
* `rtl837x_dsa_ops.c` returns `DSA_TAG_PROTO_VSC73XX_8021Q`.
* The same driver deliberately keeps the proprietary RTL8_4/0x8899 CPU tag
  disabled because the IPQ5332 EDMA checksum parser must parse past the CPU
  tag.

The change is documentation-only. It does not alter the selected Kconfig
symbol, the module list, the tag protocol, or runtime behavior.

## Validation

* `git diff --check`
* Cross-checked the README against the package Makefile and DSA source.
* No Flint 3 hardware is required for this documentation correction.

## Review request

Please verify that `tag_vsc73xx_8021q.ko` is the intended packaged module for
the current RTL837x `tag_8021q` implementation and that the IPQ5332 parser
constraint is stated accurately. If the preferred user-facing terminology is
different, I can adjust the README while preserving the package/source facts.

## Confidence

High for the file/module mismatch and the documentation-only nature of the
change. Runtime hardware behavior is unchanged and therefore not claimed as
hardware-tested here.
