### PR TITLE
rtl837x: add DSA port mirroring

### DIFF
--- a/package/kernel/rtl837x/src/rtl837x_common.h
+++ b/package/kernel/rtl837x/src/rtl837x_common.h
@@ -132,6 +132,8 @@ struct rtk_gsw {
 	int mirror_port;
 	u32 mirror_rx_mask;
 	u32 mirror_tx_mask;
+	bool mirror_direction_valid;
+	bool mirror_ingress;
 	struct net_device *ethernet_master;
 	struct sfp_bus *sfp_bus;
 

--- a/package/kernel/rtl837x/src/rtl837x_common.h
+++ b/package/kernel/rtl837x/src/rtl837x_common.h
@@ -127,6 +127,11 @@ struct rtk_gsw {
 	/* Hardware-indexed mask of ports with BR_ISOLATED enabled. */
 	u32 isolated_port_mask;
 	struct mutex isolation_lock;
+	bool port_enabled[RTK_MAX_NUM_OF_PORT];
+	/* RTL837x has one global mirror destination and separate RX/TX masks. */
+	int mirror_port;
+	u32 mirror_rx_mask;
+	u32 mirror_tx_mask;
 	struct net_device *ethernet_master;
 	struct sfp_bus *sfp_bus;
 

--- a/package/kernel/rtl837x/src/rtl837x_common.h
+++ b/package/kernel/rtl837x/src/rtl837x_common.h
@@ -132,6 +132,8 @@ struct rtk_gsw {
 	int mirror_port;
 	u32 mirror_rx_mask;
 	u32 mirror_tx_mask;
+	unsigned int mirror_rx_refcnt[RTK_MAX_NUM_OF_PORT];
+	unsigned int mirror_tx_refcnt[RTK_MAX_NUM_OF_PORT];
 	bool mirror_direction_valid;
 	bool mirror_ingress;
 	struct net_device *ethernet_master;

--- a/package/kernel/rtl837x/src/rtl837x_dsa_ops.c
+++ b/package/kernel/rtl837x/src/rtl837x_dsa_ops.c
@@ -697,14 +697,11 @@ static int rtl837x_read_ethtool_stat(int port, rtk_stat_port_type_t counter,
 }
 
 static int rtl837x_mirror_set_config(int mirror_port, u32 rx_mask,
-					     u32 tx_mask)
+					     u32 tx_mask, bool ingress)
 {
 	rtk_port_mir_set_t mir = {
 		.mtp_port = mirror_port,
-		/* The RTL8372N reference configuration uses both masks with the
-		 * selector at its default value.
-		 */
-		.rx_tx_sel = TX_DIR,
+		.rx_tx_sel = ingress ? RX_DIR : TX_DIR,
 	};
 
 	mir.rx_pmsk.bits[0] = rx_mask;
@@ -722,6 +719,7 @@ static int rtl837x_port_mirror_add(struct dsa_switch *ds, int port,
 	u32 rx_mask = gsw->mirror_rx_mask;
 	u32 tx_mask = gsw->mirror_tx_mask;
 	bool active = rx_mask || tx_mask;
+	int rollback_ret;
 	int ret;
 
 	if (!rtl837x_valid_port(gsw, port) ||
@@ -741,14 +739,35 @@ static int rtl837x_port_mirror_add(struct dsa_switch *ds, int port,
 		return -EBUSY;
 	}
 
+	/* rx_tx_sel is a single global hardware bit, so the chip cannot
+	 * represent ingress and egress mirror rules at the same time.
+	 */
+	if (active && gsw->mirror_direction_valid &&
+	    gsw->mirror_ingress != ingress) {
+		NL_SET_ERR_MSG_MOD(extack,
+				   "RTL837x supports one mirror direction at a time");
+		return -EOPNOTSUPP;
+	}
+
 	if (ingress)
 		rx_mask |= BIT(port);
 	else
 		tx_mask |= BIT(port);
 
 	ret = rtl837x_mirror_set_config(mirror->to_local_port, rx_mask,
-					       tx_mask);
+					       tx_mask, ingress);
 	if (ret) {
+		rollback_ret = active ?
+			rtl837x_mirror_set_config(gsw->mirror_port,
+						  gsw->mirror_rx_mask,
+						  gsw->mirror_tx_mask,
+						  gsw->mirror_ingress) :
+			rtl837x_mirror_set_config(mirror->to_local_port, 0, 0,
+						  ingress);
+		if (rollback_ret)
+			dev_err(ds->dev,
+				"failed to restore RTL837x mirror after update failure: %d\n",
+				rollback_ret);
 		NL_SET_ERR_MSG_MOD(extack, "Failed to program RTL837x mirror");
 		return ret;
 	}
@@ -761,6 +780,12 @@ static int rtl837x_port_mirror_add(struct dsa_switch *ds, int port,
 			/* Best effort: do not leave a partially configured mirror
 			 * enabled if the second hardware operation fails.
 			 */
+			rollback_ret = rtl837x_mirror_set_config(
+					mirror->to_local_port, 0, 0, ingress);
+			if (rollback_ret)
+				dev_err(ds->dev,
+					"failed to clear RTL837x mirror after enable failure: %d\n",
+					rollback_ret);
 			disable_ret = rtl837x_to_errno(rtk_mirror_set_en(DISABLED));
 			if (disable_ret)
 				dev_err(ds->dev,
@@ -775,6 +800,8 @@ static int rtl837x_port_mirror_add(struct dsa_switch *ds, int port,
 	gsw->mirror_port = mirror->to_local_port;
 	gsw->mirror_rx_mask = rx_mask;
 	gsw->mirror_tx_mask = tx_mask;
+	gsw->mirror_direction_valid = true;
+	gsw->mirror_ingress = ingress;
 
 	return 0;
 }
@@ -785,7 +812,7 @@ static void rtl837x_port_mirror_del(struct dsa_switch *ds, int port,
 	struct rtk_gsw *gsw = ds->priv;
 	u32 rx_mask = gsw->mirror_rx_mask;
 	u32 tx_mask = gsw->mirror_tx_mask;
-	int ret;
+	int rollback_ret, ret;
 
 	if (!rtl837x_valid_port(gsw, port) ||
 	    !rtl837x_valid_port(gsw, mirror->to_local_port))
@@ -793,6 +820,8 @@ static void rtl837x_port_mirror_del(struct dsa_switch *ds, int port,
 
 	if ((!gsw->mirror_rx_mask && !gsw->mirror_tx_mask) ||
 	    gsw->mirror_port != mirror->to_local_port ||
+	    (gsw->mirror_direction_valid &&
+	     gsw->mirror_ingress != mirror->ingress) ||
 	    (mirror->ingress ? !(gsw->mirror_rx_mask & BIT(port)) :
 					 !(gsw->mirror_tx_mask & BIT(port))))
 		return;
@@ -810,14 +839,30 @@ static void rtl837x_port_mirror_del(struct dsa_switch *ds, int port,
 			return;
 		}
 
+		ret = rtl837x_mirror_set_config(gsw->mirror_port, 0, 0,
+						gsw->mirror_ingress);
+		if (ret)
+			dev_warn(ds->dev,
+				 "failed to clear RTL837x mirror masks: %d\n", ret);
+
 		gsw->mirror_port = -1;
 		gsw->mirror_rx_mask = 0;
 		gsw->mirror_tx_mask = 0;
+		gsw->mirror_direction_valid = false;
+		gsw->mirror_ingress = false;
 		return;
 	}
 
-	ret = rtl837x_mirror_set_config(gsw->mirror_port, rx_mask, tx_mask);
+	ret = rtl837x_mirror_set_config(gsw->mirror_port, rx_mask, tx_mask,
+					gsw->mirror_ingress);
 	if (ret) {
+		rollback_ret = rtl837x_mirror_set_config(
+				gsw->mirror_port, gsw->mirror_rx_mask,
+				gsw->mirror_tx_mask, gsw->mirror_ingress);
+		if (rollback_ret)
+			dev_err(ds->dev,
+				"failed to restore RTL837x mirror after delete failure: %d\n",
+				rollback_ret);
 		dev_err(ds->dev, "failed to update RTL837x mirror: %d\n", ret);
 		return;
 	}
@@ -1262,6 +1307,8 @@ static int rtl837x_setup(struct dsa_switch *ds)
 	gsw->mirror_port = -1;
 	gsw->mirror_rx_mask = 0;
 	gsw->mirror_tx_mask = 0;
+	gsw->mirror_direction_valid = false;
+	gsw->mirror_ingress = false;
 	gsw->port_enabled[gsw->cpu_port] = true;
 
 	for (port = 0; port < RTK_MAX_NUM_OF_PORT; port++) {
@@ -1312,12 +1359,24 @@ static void rtl837x_teardown(struct dsa_switch *ds)
 	dsa_tag_8021q_unregister(ds);
 	rtnl_unlock();
 
-	rtl837x_mdio_teardown(ds);
-	if (rtk_mirror_set_en(DISABLED))
+	ret = rtl837x_to_errno(rtk_mirror_set_en(DISABLED));
+	if (ret)
 		dev_warn(gsw->dev, "failed to disable RTL837x mirror\n");
+	else if (gsw->mirror_port >= 0) {
+		ret = rtl837x_mirror_set_config(gsw->mirror_port, 0, 0,
+						gsw->mirror_ingress);
+		if (ret)
+			dev_warn(gsw->dev,
+				 "failed to clear RTL837x mirror masks on teardown: %d\n",
+				 ret);
+	}
+
+	rtl837x_mdio_teardown(ds);
 	gsw->mirror_port = -1;
 	gsw->mirror_rx_mask = 0;
 	gsw->mirror_tx_mask = 0;
+	gsw->mirror_direction_valid = false;
+	gsw->mirror_ingress = false;
 	ret = rtk_cpuTag_enable_set(EXTERNAL_CPU, DISABLED);
 	if (ret)
 		dev_err(ds->dev, "failed to disable CPU tag during teardown: %d\n", ret);

--- a/package/kernel/rtl837x/src/rtl837x_dsa_ops.c
+++ b/package/kernel/rtl837x/src/rtl837x_dsa_ops.c
@@ -866,25 +866,54 @@ static void rtl837x_port_mirror_del(struct dsa_switch *ds, int port,
 					 !gsw->mirror_tx_refcnt[port]))
 		return;
 
-	if (mirror->ingress)
-		gsw->mirror_rx_refcnt[port]--;
-	else
+	/* Multiple filters for one source share one hardware mask bit.  Removing
+	 * one of them only changes the reference count until the last filter is
+	 * gone; no hardware transaction is needed in that case.
+	 */
+	if (mirror->ingress) {
+		if (gsw->mirror_rx_refcnt[port] > 1) {
+			gsw->mirror_rx_refcnt[port]--;
+			return;
+		}
+	} else if (gsw->mirror_tx_refcnt[port] > 1) {
 		gsw->mirror_tx_refcnt[port]--;
+		return;
+	}
 
-	rtl837x_mirror_masks_from_refcnt(gsw, &rx_mask, &tx_mask);
+	rx_mask = gsw->mirror_rx_mask;
+	tx_mask = gsw->mirror_tx_mask;
+	if (mirror->ingress)
+		rx_mask &= ~BIT(port);
+	else
+		tx_mask &= ~BIT(port);
 
 	if (!rx_mask && !tx_mask) {
 		ret = rtl837x_to_errno(rtk_mirror_set_en(DISABLED));
 		if (ret) {
 			dev_err(ds->dev,
 				"failed to disable RTL837x mirror: %d\n", ret);
+			return;
 		}
 
 		ret = rtl837x_mirror_set_config(mirror->to_local_port, 0, 0,
 						mirror->ingress);
-		if (ret)
+		if (ret) {
 			dev_warn(ds->dev,
 				 "failed to clear RTL837x mirror masks: %d\n", ret);
+			rollback_ret = rtl837x_mirror_set_config(
+					mirror->to_local_port, gsw->mirror_rx_mask,
+					gsw->mirror_tx_mask, gsw->mirror_ingress);
+			if (rollback_ret)
+				dev_err(ds->dev,
+					"failed to restore RTL837x mirror masks after delete failure: %d\n",
+					rollback_ret);
+			rollback_ret = rtl837x_to_errno(rtk_mirror_set_en(ENABLED));
+			if (rollback_ret)
+				dev_err(ds->dev,
+					"failed to re-enable RTL837x mirror after delete failure: %d\n",
+					rollback_ret);
+			return;
+		}
 
 		gsw->mirror_port = -1;
 		gsw->mirror_rx_mask = 0;
@@ -896,24 +925,17 @@ static void rtl837x_port_mirror_del(struct dsa_switch *ds, int port,
 		return;
 	}
 
-	if (rx_mask == gsw->mirror_rx_mask &&
-	    tx_mask == gsw->mirror_tx_mask)
-		return;
-
 	ret = rtl837x_mirror_set_config(gsw->mirror_port, rx_mask, tx_mask,
 					gsw->mirror_ingress);
 	if (ret) {
-		rollback_ret = rtl837x_mirror_set_config(
-				gsw->mirror_port, gsw->mirror_rx_mask,
-				gsw->mirror_tx_mask, gsw->mirror_ingress);
-		if (rollback_ret)
-			dev_err(ds->dev,
-				"failed to restore RTL837x mirror after delete failure: %d\n",
-				rollback_ret);
 		dev_err(ds->dev, "failed to update RTL837x mirror: %d\n", ret);
 		return;
 	}
 
+	if (mirror->ingress)
+		gsw->mirror_rx_refcnt[port]--;
+	else
+		gsw->mirror_tx_refcnt[port]--;
 	gsw->mirror_rx_mask = rx_mask;
 	gsw->mirror_tx_mask = tx_mask;
 }

--- a/package/kernel/rtl837x/src/rtl837x_dsa_ops.c
+++ b/package/kernel/rtl837x/src/rtl837x_dsa_ops.c
@@ -696,6 +696,34 @@ static int rtl837x_read_ethtool_stat(int port, rtk_stat_port_type_t counter,
 	return 0;
 }
 
+static bool rtl837x_mirror_active(const struct rtk_gsw *gsw)
+{
+	int port;
+
+	for (port = 0; port < RTK_MAX_NUM_OF_PORT; port++)
+		if (gsw->mirror_rx_refcnt[port] ||
+		    gsw->mirror_tx_refcnt[port])
+			return true;
+
+	return false;
+}
+
+static void rtl837x_mirror_masks_from_refcnt(const struct rtk_gsw *gsw,
+						     u32 *rx_mask, u32 *tx_mask)
+{
+	int port;
+
+	*rx_mask = 0;
+	*tx_mask = 0;
+
+	for (port = 0; port < RTK_MAX_NUM_OF_PORT; port++) {
+		if (gsw->mirror_rx_refcnt[port])
+			*rx_mask |= BIT(port);
+		if (gsw->mirror_tx_refcnt[port])
+			*tx_mask |= BIT(port);
+	}
+}
+
 static int rtl837x_mirror_set_config(int mirror_port, u32 rx_mask,
 					     u32 tx_mask, bool ingress)
 {
@@ -716,9 +744,8 @@ static int rtl837x_port_mirror_add(struct dsa_switch *ds, int port,
 					   struct netlink_ext_ack *extack)
 {
 	struct rtk_gsw *gsw = ds->priv;
-	u32 rx_mask = gsw->mirror_rx_mask;
-	u32 tx_mask = gsw->mirror_tx_mask;
-	bool active = rx_mask || tx_mask;
+	u32 rx_mask, tx_mask;
+	bool active;
 	int rollback_ret;
 	int ret;
 
@@ -731,6 +758,15 @@ static int rtl837x_port_mirror_add(struct dsa_switch *ds, int port,
 				   "Mirror source and destination must differ");
 		return -EINVAL;
 	}
+
+	if (mirror->to_local_port == gsw->cpu_port) {
+		NL_SET_ERR_MSG_MOD(extack,
+				   "RTL837x cannot mirror traffic to the CPU port");
+		return -EOPNOTSUPP;
+	}
+
+	active = rtl837x_mirror_active(gsw);
+	rtl837x_mirror_masks_from_refcnt(gsw, &rx_mask, &tx_mask);
 
 	/* The RTL837x mirror block has one global monitor port. */
 	if (active && gsw->mirror_port != mirror->to_local_port) {
@@ -797,6 +833,11 @@ static int rtl837x_port_mirror_add(struct dsa_switch *ds, int port,
 		}
 	}
 
+	if (ingress)
+		gsw->mirror_rx_refcnt[port]++;
+	else
+		gsw->mirror_tx_refcnt[port]++;
+
 	gsw->mirror_port = mirror->to_local_port;
 	gsw->mirror_rx_mask = rx_mask;
 	gsw->mirror_tx_mask = tx_mask;
@@ -810,37 +851,37 @@ static void rtl837x_port_mirror_del(struct dsa_switch *ds, int port,
 	struct dsa_mall_mirror_tc_entry *mirror)
 {
 	struct rtk_gsw *gsw = ds->priv;
-	u32 rx_mask = gsw->mirror_rx_mask;
-	u32 tx_mask = gsw->mirror_tx_mask;
+	u32 rx_mask, tx_mask;
 	int rollback_ret, ret;
 
 	if (!rtl837x_valid_port(gsw, port) ||
 	    !rtl837x_valid_port(gsw, mirror->to_local_port))
 		return;
 
-	if ((!gsw->mirror_rx_mask && !gsw->mirror_tx_mask) ||
+	if (!rtl837x_mirror_active(gsw) ||
 	    gsw->mirror_port != mirror->to_local_port ||
 	    (gsw->mirror_direction_valid &&
 	     gsw->mirror_ingress != mirror->ingress) ||
-	    (mirror->ingress ? !(gsw->mirror_rx_mask & BIT(port)) :
-					 !(gsw->mirror_tx_mask & BIT(port))))
+	    (mirror->ingress ? !gsw->mirror_rx_refcnt[port] :
+					 !gsw->mirror_tx_refcnt[port]))
 		return;
 
 	if (mirror->ingress)
-		rx_mask &= ~BIT(port);
+		gsw->mirror_rx_refcnt[port]--;
 	else
-		tx_mask &= ~BIT(port);
+		gsw->mirror_tx_refcnt[port]--;
+
+	rtl837x_mirror_masks_from_refcnt(gsw, &rx_mask, &tx_mask);
 
 	if (!rx_mask && !tx_mask) {
 		ret = rtl837x_to_errno(rtk_mirror_set_en(DISABLED));
 		if (ret) {
 			dev_err(ds->dev,
 				"failed to disable RTL837x mirror: %d\n", ret);
-			return;
 		}
 
-		ret = rtl837x_mirror_set_config(gsw->mirror_port, 0, 0,
-						gsw->mirror_ingress);
+		ret = rtl837x_mirror_set_config(mirror->to_local_port, 0, 0,
+						mirror->ingress);
 		if (ret)
 			dev_warn(ds->dev,
 				 "failed to clear RTL837x mirror masks: %d\n", ret);
@@ -848,10 +889,16 @@ static void rtl837x_port_mirror_del(struct dsa_switch *ds, int port,
 		gsw->mirror_port = -1;
 		gsw->mirror_rx_mask = 0;
 		gsw->mirror_tx_mask = 0;
+		memset(gsw->mirror_rx_refcnt, 0, sizeof(gsw->mirror_rx_refcnt));
+		memset(gsw->mirror_tx_refcnt, 0, sizeof(gsw->mirror_tx_refcnt));
 		gsw->mirror_direction_valid = false;
 		gsw->mirror_ingress = false;
 		return;
 	}
+
+	if (rx_mask == gsw->mirror_rx_mask &&
+	    tx_mask == gsw->mirror_tx_mask)
+		return;
 
 	ret = rtl837x_mirror_set_config(gsw->mirror_port, rx_mask, tx_mask,
 					gsw->mirror_ingress);
@@ -1307,6 +1354,8 @@ static int rtl837x_setup(struct dsa_switch *ds)
 	gsw->mirror_port = -1;
 	gsw->mirror_rx_mask = 0;
 	gsw->mirror_tx_mask = 0;
+	memset(gsw->mirror_rx_refcnt, 0, sizeof(gsw->mirror_rx_refcnt));
+	memset(gsw->mirror_tx_refcnt, 0, sizeof(gsw->mirror_tx_refcnt));
 	gsw->mirror_direction_valid = false;
 	gsw->mirror_ingress = false;
 	gsw->port_enabled[gsw->cpu_port] = true;
@@ -1375,6 +1424,8 @@ static void rtl837x_teardown(struct dsa_switch *ds)
 	gsw->mirror_port = -1;
 	gsw->mirror_rx_mask = 0;
 	gsw->mirror_tx_mask = 0;
+	memset(gsw->mirror_rx_refcnt, 0, sizeof(gsw->mirror_rx_refcnt));
+	memset(gsw->mirror_tx_refcnt, 0, sizeof(gsw->mirror_tx_refcnt));
 	gsw->mirror_direction_valid = false;
 	gsw->mirror_ingress = false;
 	ret = rtk_cpuTag_enable_set(EXTERNAL_CPU, DISABLED);

--- a/package/kernel/rtl837x/src/rtl837x_dsa_ops.c
+++ b/package/kernel/rtl837x/src/rtl837x_dsa_ops.c
@@ -18,6 +18,7 @@
 
 #include "./rtl837x_common.h"
 #include "./rtk-api/l2.h"
+#include "./rtk-api/mirror.h"
 #include "./rtk-api/dal/rtl8373/dal_rtl8373_stp.h"
 
 static int rtl837x_to_errno(int ret)
@@ -695,6 +696,136 @@ static int rtl837x_read_ethtool_stat(int port, rtk_stat_port_type_t counter,
 	return 0;
 }
 
+static int rtl837x_mirror_set_config(int mirror_port, u32 rx_mask,
+					     u32 tx_mask)
+{
+	rtk_port_mir_set_t mir = {
+		.mtp_port = mirror_port,
+		/* The RTL8372N reference configuration uses both masks with the
+		 * selector at its default value.
+		 */
+		.rx_tx_sel = TX_DIR,
+	};
+
+	mir.rx_pmsk.bits[0] = rx_mask;
+	mir.tx_pmsk.bits[0] = tx_mask;
+
+	return rtl837x_to_errno(rtk_mirror_portBased_set(&mir));
+}
+
+static int rtl837x_port_mirror_add(struct dsa_switch *ds, int port,
+					   struct dsa_mall_mirror_tc_entry *mirror,
+					   bool ingress,
+					   struct netlink_ext_ack *extack)
+{
+	struct rtk_gsw *gsw = ds->priv;
+	u32 rx_mask = gsw->mirror_rx_mask;
+	u32 tx_mask = gsw->mirror_tx_mask;
+	bool active = rx_mask || tx_mask;
+	int ret;
+
+	if (!rtl837x_valid_port(gsw, port) ||
+	    !rtl837x_valid_port(gsw, mirror->to_local_port))
+		return -EINVAL;
+
+	if (port == mirror->to_local_port) {
+		NL_SET_ERR_MSG_MOD(extack,
+				   "Mirror source and destination must differ");
+		return -EINVAL;
+	}
+
+	/* The RTL837x mirror block has one global monitor port. */
+	if (active && gsw->mirror_port != mirror->to_local_port) {
+		NL_SET_ERR_MSG_MOD(extack,
+				   "RTL837x supports one mirror destination port");
+		return -EBUSY;
+	}
+
+	if (ingress)
+		rx_mask |= BIT(port);
+	else
+		tx_mask |= BIT(port);
+
+	ret = rtl837x_mirror_set_config(mirror->to_local_port, rx_mask,
+					       tx_mask);
+	if (ret) {
+		NL_SET_ERR_MSG_MOD(extack, "Failed to program RTL837x mirror");
+		return ret;
+	}
+
+	if (!active) {
+		ret = rtl837x_to_errno(rtk_mirror_set_en(ENABLED));
+		if (ret) {
+			int disable_ret;
+
+			/* Best effort: do not leave a partially configured mirror
+			 * enabled if the second hardware operation fails.
+			 */
+			disable_ret = rtl837x_to_errno(rtk_mirror_set_en(DISABLED));
+			if (disable_ret)
+				dev_err(ds->dev,
+					"failed to roll back RTL837x mirror: %d\n",
+					disable_ret);
+			NL_SET_ERR_MSG_MOD(extack,
+					   "Failed to enable RTL837x mirror");
+			return ret;
+		}
+	}
+
+	gsw->mirror_port = mirror->to_local_port;
+	gsw->mirror_rx_mask = rx_mask;
+	gsw->mirror_tx_mask = tx_mask;
+
+	return 0;
+}
+
+static void rtl837x_port_mirror_del(struct dsa_switch *ds, int port,
+	struct dsa_mall_mirror_tc_entry *mirror)
+{
+	struct rtk_gsw *gsw = ds->priv;
+	u32 rx_mask = gsw->mirror_rx_mask;
+	u32 tx_mask = gsw->mirror_tx_mask;
+	int ret;
+
+	if (!rtl837x_valid_port(gsw, port) ||
+	    !rtl837x_valid_port(gsw, mirror->to_local_port))
+		return;
+
+	if ((!gsw->mirror_rx_mask && !gsw->mirror_tx_mask) ||
+	    gsw->mirror_port != mirror->to_local_port ||
+	    (mirror->ingress ? !(gsw->mirror_rx_mask & BIT(port)) :
+					 !(gsw->mirror_tx_mask & BIT(port))))
+		return;
+
+	if (mirror->ingress)
+		rx_mask &= ~BIT(port);
+	else
+		tx_mask &= ~BIT(port);
+
+	if (!rx_mask && !tx_mask) {
+		ret = rtl837x_to_errno(rtk_mirror_set_en(DISABLED));
+		if (ret) {
+			dev_err(ds->dev,
+				"failed to disable RTL837x mirror: %d\n", ret);
+			return;
+		}
+
+		gsw->mirror_port = -1;
+		gsw->mirror_rx_mask = 0;
+		gsw->mirror_tx_mask = 0;
+		return;
+	}
+
+	ret = rtl837x_mirror_set_config(gsw->mirror_port, rx_mask, tx_mask);
+	if (ret) {
+		dev_err(ds->dev, "failed to update RTL837x mirror: %d\n", ret);
+		return;
+	}
+
+	gsw->mirror_rx_mask = rx_mask;
+	gsw->mirror_tx_mask = tx_mask;
+}
+
 static u64 rtl837x_read_stat(int port, u32 counter)
 {
 	u64 value;
@@ -1128,6 +1259,10 @@ static int rtl837x_setup(struct dsa_switch *ds)
 	memset(gsw->tag8021q_pvid_valid, 0, sizeof(gsw->tag8021q_pvid_valid));
 	memset(gsw->bridge_pvid, 0, sizeof(gsw->bridge_pvid));
 	memset(gsw->bridge_pvid_valid, 0, sizeof(gsw->bridge_pvid_valid));
+	gsw->mirror_port = -1;
+	gsw->mirror_rx_mask = 0;
+	gsw->mirror_tx_mask = 0;
+	gsw->port_enabled[gsw->cpu_port] = true;
 
 	for (port = 0; port < RTK_MAX_NUM_OF_PORT; port++) {
 		if (!rtl837x_valid_port(gsw, port))
@@ -1178,6 +1313,11 @@ static void rtl837x_teardown(struct dsa_switch *ds)
 	rtnl_unlock();
 
 	rtl837x_mdio_teardown(ds);
+	if (rtk_mirror_set_en(DISABLED))
+		dev_warn(gsw->dev, "failed to disable RTL837x mirror\n");
+	gsw->mirror_port = -1;
+	gsw->mirror_rx_mask = 0;
+	gsw->mirror_tx_mask = 0;
 	ret = rtk_cpuTag_enable_set(EXTERNAL_CPU, DISABLED);
 	if (ret)
 		dev_err(ds->dev, "failed to disable CPU tag during teardown: %d\n", ret);
@@ -1959,6 +2099,8 @@ static const struct dsa_switch_ops rtl837x_dsa_ops = {
 	.port_vlan_del = rtl837x_port_vlan_del,
 	.port_fdb_add = rtl837x_port_fdb_add,
 	.port_fdb_del = rtl837x_port_fdb_del,
+	.port_mirror_add = rtl837x_port_mirror_add,
+	.port_mirror_del = rtl837x_port_mirror_del,
 	.tag_8021q_vlan_add = rtl837x_tag_8021q_vlan_add,
 	.tag_8021q_vlan_del = rtl837x_tag_8021q_vlan_del,
 };


### PR DESCRIPTION
## Summary

Wire the existing RTL8372 mirror block into the DSA `port_mirror_add` and
`port_mirror_del` callbacks.

The implementation uses the existing RTL837x RTK/DAL mirror API, which
provides one monitor port and independent RX/TX source masks.

## Why this is correct

The DSA callback signatures and `mirror->ingress` lifecycle match the kernel
API. DSA port indices are physical RTL837x port numbers in this driver, so
the source masks use `BIT(port)`. The DAL validates the monitor/source
relationship and programs the existing RTL8373 mirror registers; no raw
register programming or undocumented feature is introduced.

The RTL837x mirror block has one global direction selector bit. The
implementation programs `rx_tx_sel` from the requested direction (`RX_DIR`
for ingress and `TX_DIR` for egress), and rejects a second rule in the
opposite direction with `-EOPNOTSUPP` and an extack instead of returning
success while mirroring nothing. A different monitor port is rejected with
`-EBUSY`, and using the CPU port as the monitor is rejected as unsupported.

Per-source, per-direction reference counts prevent deleting one duplicate
rule from disabling another rule that still requires the same hardware mask
bit. Shadow state is updated only after successful hardware programming. The
last-rule delete disables the block and clears both masks; if either the
disable or clear operation fails, the shadow configuration is retained and a
best-effort rollback restores the previous hardware configuration. Setup and
teardown reset the mirror shadow state. CPU-port monitoring, RSPAN, sampling,
ACL mirroring, and multiple monitor groups remain outside the scope.

## Validation

- Rebased directly onto current `flint3-be9300`
  (`a75f06ba2ff25f108751e46428fbb4b709b62554`) with only mechanical conflict
  resolution; the final diff is limited to the two RTL837x mirror files.
- `git diff --check`: passed.
- `scripts/checkpatch.pl --no-tree --terse`: passed with 0 errors and 0
  warnings for the final patch.
- Cross-checked DSA callback signatures and the RTL8373 mirror DAL/register
  definitions.
- The final-delete failure handling was tightened in commit `c5fb1b9ee9`.
- No package build or hardware validation is claimed.

This PR remains Draft pending maintainer review and hardware validation.

## Requested hardware validation

Please verify ingress-only and egress-only `tc matchall` rules, multiple
same-direction sources including duplicate registration/deletion, rejection
of mixed directions and a second monitor port, CPU-port rejection, final-rule
deletion, teardown and reload, and behavior after an injected MDIO/SMI
failure.
