### PR TITLE
rtl837x: handle CPU status read failures

### DIFF
--- a/package/kernel/rtl837x/src/rtl837x_mdio.c
+++ b/package/kernel/rtl837x/src/rtl837x_mdio.c
@@ -537,12 +537,20 @@ static void rtl837x_status_check_work_func(struct work_struct *work)
 {
 	struct rtk_gsw *gsw = container_of(work, struct rtk_gsw, status_check_work.work);
 
-	rtk_port_status_t port_status;
+	rtk_port_status_t port_status = { 0 };
+	int ret;
 
 	if (!gsw->ethernet_master)
 		return;
 
-	rtk_port_macStatus_get(gsw->cpu_port, &port_status);
+	ret = rtk_port_macStatus_get(gsw->cpu_port, &port_status);
+	if (ret) {
+		dev_warn(gsw->dev,
+			 "failed to read CPU port %u status, error:%d\n",
+			 gsw->cpu_port, ret);
+		goto requeue;
+	}
+
 	if (!port_status.link)
 	{
 		if (gsw->cpu_port != UTP_PORT3 && gsw->cpu_port != UTP_PORT8)
@@ -567,6 +575,7 @@ static void rtl837x_status_check_work_func(struct work_struct *work)
 		mdelay(2000);
 	}
 
+requeue:
 	queue_delayed_work_on(smp_processor_id(), 
 						system_wq, 
 						&gsw->status_check_work, 


### PR DESCRIPTION
## Summary

The RTL837x status worker ignored the return value of `rtk_port_macStatus_get()`. Its `rtk_port_status_t` destination was also uninitialized. If an MDIO read failed, the worker could consume an invalid `link` value and enter the SerDes recovery sequence unnecessarily.

This patch:

- checks the return value of `rtk_port_macStatus_get()`;
- logs the SDK error and skips recovery when the status cannot be read;
- reschedules the worker through its existing polling path;
- initializes the status structure before use;
- leaves the successful link-up and link-down paths unchanged.

## Why this solution is believed to be correct

`rtk_port_macStatus_get()` returns an `rtk_api_ret_t`, so a failed status read must be handled before inspecting the output structure. A failed read is not evidence that the CPU port is down; therefore it should not trigger closing the Ethernet master, disabling SerDes, waiting, and reopening the interface. Retrying at the existing worker interval is the least disruptive recovery for a transient management-bus failure.

The change is deliberately limited to this error path. It does not add new register programming or alter the existing recovery behavior after a successful status read.

## Validation

- `scripts/checkpatch.pl --no-tree -`: 0 errors, 0 warnings.
- `git show --check`: clean.
- No Flint 3 hardware was available for runtime validation.

## Review request

Please verify on hardware, or with an injected MDIO/status-read failure, that skipping SerDes recovery and retrying on the next worker interval is the expected behavior. Confidence is high (approximately 95%) for preventing a false recovery action; runtime confirmation is still valuable for the SDK error behavior and retry interval.