### PR TITLE
rtl837x: propagate MDIO read errors

### DIFF
--- a/package/kernel/rtl837x/src/rtl837x_mdio.c
+++ b/package/kernel/rtl837x/src/rtl837x_mdio.c
@@ -86,6 +86,9 @@ static int rtl837x_mdio_write(void *ctx, u32 reg, u32 val)
 
 	// check busy
 	ret = bus->read(bus, priv->mdio_addr, MDC_MDIO_CTRL_REG);
+	if (ret < 0)
+		goto out_unlock;
+
     if (ret & 0x4) {
 		ret = RT_ERR_BUSYWAIT_TIMEOUT;
 		goto out_unlock;
@@ -109,6 +112,9 @@ static int rtl837x_mdio_write(void *ctx, u32 reg, u32 val)
 
 	// check busy
 	ret = bus->read(bus, priv->mdio_addr, MDC_MDIO_CTRL_REG);
+	if (ret < 0)
+		goto out_unlock;
+
     if (ret & 0x4) {
 		ret = RT_ERR_BUSYWAIT_TIMEOUT;
 		goto out_unlock;
@@ -130,6 +136,9 @@ static int rtl837x_mdio_read(void *ctx, u32 reg, u32 *val)
 
 	// check busy
 	ret = bus->read(bus, priv->mdio_addr, MDC_MDIO_CTRL_REG);
+	if (ret < 0)
+		goto out_unlock;
+
     if (ret & 0x4) {
 		ret = RT_ERR_BUSYWAIT_TIMEOUT;
 		goto out_unlock;
@@ -145,6 +154,9 @@ static int rtl837x_mdio_read(void *ctx, u32 reg, u32 *val)
 
 	// check busy
 	ret = bus->read(bus, priv->mdio_addr, MDC_MDIO_CTRL_REG);
+	if (ret < 0)
+		goto out_unlock;
+
     if (ret & 0x4) {
 		ret = RT_ERR_BUSYWAIT_TIMEOUT;
 		goto out_unlock;
@@ -152,7 +164,16 @@ static int rtl837x_mdio_read(void *ctx, u32 reg, u32 *val)
 
 
 	val_l = bus->read(bus, priv->mdio_addr, MDC_MDIO_DATA_LOW);
+	if (val_l < 0) {
+		ret = val_l;
+		goto out_unlock;
+	}
+
 	val_h = bus->read(bus, priv->mdio_addr, MDC_MDIO_DATA_HIGH);
+	if (val_h < 0) {
+		ret = val_h;
+		goto out_unlock;
+	}
 
     *val = val_l & 0xffff;
     *val |= (val_h & 0xffff) << 16;


### PR DESCRIPTION
## Summary

The RTL837x regmap callbacks access the switch through `mii_bus` reads and
writes. The callbacks currently inspect only the busy bit of control-register
reads. They also combine the results of the low and high data-register reads
without checking either result.

If an underlying MDIO read returns a negative error, the current code can
therefore:

- continue issuing transactions after a failed control read;
- interpret a failed control read as a non-busy status;
- assemble an invalid register value from a failed data read;
- return success to regmap and hide the SMI/MDIO failure from the Realtek API.

This patch checks negative results from every `mii_bus->read()` call before
examining the busy bit or using the returned data. Existing busy-timeout
handling is unchanged, and write errors were already propagated by the
existing `if (ret)` checks.

## Why this solution is believed to be correct

The `mii_bus` read callback returns a non-negative register value on success
and a negative errno on transport failure. A negative result is not a valid
switch-register value and must not be masked or tested as a hardware status
bit.

Returning the read error through the regmap callback lets the existing
Realtek ASIC helpers convert it to their normal SMI error path. The output
value is also left untouched when either data half cannot be read. The change
does not alter successful reads, busy detection, register addressing, or the
MDIO write sequence.

## Validation

- `scripts/checkpatch.pl --no-tree -`: 0 errors, 0 warnings.
- `git show --check`: clean.
- The patch changes one file and only adds error checks.
- No Flint 3 hardware was available for runtime validation.

## Review request

Please verify on hardware, or with an injected MDIO read failure, that the
error reaches the regmap/Realtek API path and that no follow-up transaction is
issued after a failed control or data read.

Confidence is high (approximately 96%) for the software correctness of this
error-path fix. Hardware confirmation remains useful for the platform-specific
MDIO error injection and recovery behavior.