### PR TITLE
rtl837x: propagate GPIO read errors

### DIFF
--- a/package/kernel/rtl837x/src/rtl837x_gpio.c
+++ b/package/kernel/rtl837x/src/rtl837x_gpio.c
@@ -44,13 +44,17 @@ static void rtl837x_gpio_set(struct gpio_chip *gc, unsigned offset, int value)
 
 static int rtl837x_gpio_get(struct gpio_chip *gc, unsigned offset)
 {
-    struct rtl837x_gpio *gpio = gpiochip_get_data(gc);
-    rtk_gpio_level_t pval;
-    uint32_t ret = gpio->gsw->pMapper->gpio_pinVal_read(offset, &pval);
-    if (ret)
-        dev_err(gpio->gsw->dev, "gpio %d: failed to read gpio val %x", offset, ret);
+	struct rtl837x_gpio *gpio = gpiochip_get_data(gc);
+	rtk_gpio_level_t pval;
+	uint32_t ret = gpio->gsw->pMapper->gpio_pinVal_read(offset, &pval);
 
-    return pval == GPIO_LEVEL_HIGH ? 1 : 0;
+	if (ret) {
+		dev_err(gpio->gsw->dev,
+			"gpio %d: failed to read gpio val %x", offset, ret);
+		return -EIO;
+	}
+
+	return pval == GPIO_LEVEL_HIGH ? 1 : 0;
 }
 
 static int rtl837x_gpio_direction_input(struct gpio_chip *gc, unsigned offset)


### PR DESCRIPTION
## Summary

The RTL837x GPIO getter logs an error from
`gpio_pinVal_read(offset, &pval)`, but then evaluates `pval` regardless of
the return value.

The RTK GPIO API can return range, null-pointer, and SMI errors. The RTL8373
DAL returns immediately on those paths and assigns `*pVal` only after a
successful register read. Therefore, the current getter can inspect an
uninitialized value and report a random GPIO level to the Linux GPIO
consumer.

This patch returns `-EIO` after logging a failed read. The existing 0/1
result for successful reads is unchanged.

## Why this solution is believed to be correct

The Linux `gpio_chip.get` callback returns either a GPIO value or a negative
errno. A failed switch-register read is not a valid low level, so returning
an error is safer than fabricating a value from an uninitialized variable.

The selected errno also matches the existing GPIO write and direction error
handling in this driver. No GPIO mux, direction, or register programming is
changed.

## Validation

- `scripts/checkpatch.pl --no-tree -`: 0 errors, 0 warnings.
- `git show --check`: clean.
- The patch changes only the GPIO getter.
- No Flint 3 hardware was available for runtime validation.

## Review request

Please verify on hardware, or with an injected GPIO SMI/read failure, that the
Linux GPIO consumer receives an error and that successful GPIO reads still
return the same value.

Confidence is high (approximately 98%) because the error path is explicit in
the DAL and the fix prevents use of an uninitialized output. Runtime
confirmation is still useful for the platform-specific SMI failure path.