### PR TITLE
rtl837x: preserve regmap init errors

### DIFF
--- a/package/kernel/rtl837x/src/rtl837x_mdio.c
+++ b/package/kernel/rtl837x/src/rtl837x_mdio.c
@@ -792,7 +792,7 @@ static int rtl837x_dsa_probe(struct mdio_device *mdiodev)
 		dev_err(dev, "regmap init failed: %d\n", ret);
 		if (master)
 			dev_put(master);
-		return -EINVAL;
+		return ret;
 	}
 
 	rc = rtl837x_mdio_nolock_regmap_config;
@@ -802,7 +802,7 @@ static int rtl837x_dsa_probe(struct mdio_device *mdiodev)
 		dev_err(dev, "regmap init failed: %d\n", ret);
 		if (master)
 			dev_put(master);
-		return -EINVAL;
+		return ret;
 	}
 
 	gsw->dev = dev;


### PR DESCRIPTION
## Summary

During `rtl837x_dsa_probe()`, both regmap initialization error paths already
extract the original error with `PTR_ERR()` and store it in `ret`, but then
return `-EINVAL` instead.

This patch returns `ret` from both paths, preserving the actual
`devm_regmap_init()` failure for the driver core and for diagnostics.

## Why this solution is believed to be correct

`devm_regmap_init()` returns an error pointer on failure. `PTR_ERR()` is the
kernel mechanism used to recover that negative errno, so replacing it with a
generic `-EINVAL` discards information supplied by the failing subsystem.

Returning the already captured `ret` is the smallest correct change. It does
not alter successful regmap setup, resource cleanup, probe ordering, or any
RTL837x register programming.

## Validation

- `scripts/checkpatch.pl --no-tree -`: 0 errors, 0 warnings.
- `git show --check`: clean.
- The patch changes only the two regmap initialization error returns.
- No Flint 3 hardware was available for runtime validation.

## Review request

Please verify that the driver should propagate the exact errno from either
regmap initialization failure rather than converting it to `-EINVAL`.

Confidence is high (approximately 99%) because the code already obtains the
exact error with `PTR_ERR()`; the patch only stops discarding it.