### PR TITLE
rtl837x: fail probe on reset GPIO errors

### DIFF
--- a/package/kernel/rtl837x/src/rtl837x_mdio.c
+++ b/package/kernel/rtl837x/src/rtl837x_mdio.c
@@ -816,7 +816,11 @@ static int rtl837x_dsa_probe(struct mdio_device *mdiodev)
 
 	gsw->reset_pin = devm_gpiod_get_optional(dev, "reset", GPIOD_OUT_LOW);
 	if (IS_ERR(gsw->reset_pin)) {
-		dev_warn(dev, "failed to get RESET GPIO!!!\n");
+		ret = PTR_ERR(gsw->reset_pin);
+		dev_err_probe(dev, ret, "failed to get reset GPIO\n");
+		if (master)
+			dev_put(master);
+		return ret;
 	}
 
 	if (!of_property_read_string(np, "rtl837x,sds0mode", &sdsmode_name) &&


### PR DESCRIPTION
## Summary

`devm_gpiod_get_optional()` returns `NULL` only when no reset GPIO is described. For other acquisition failures, including `-EPROBE_DEFER`, it returns an error pointer. The probe currently logs that failure and continues, which can register the switch without the requested reset resource and can hide deferred-probe conditions.

Return the original error after dropping the reference acquired by `of_find_net_device_by_node()`. The no-GPIO path and the successful-GPIO path are unchanged, while deferred dependencies can be retried by the driver core.

## Validation

- `git diff --check`
- checkpatch on the proposed diff: no errors or warnings
- No Flint 3 hardware was available for runtime testing

Confidence: 98% based on the Linux GPIO consumer contract and the local probe cleanup path.

Please verify on hardware or with representative device trees covering:

- no `reset-gpios` property;
- a valid reset GPIO;
- a reset provider that returns `-EPROBE_DEFER` or another acquisition error.