### PR TITLE
rtl837x: handle GPIO controller registration errors

### DIFF
--- a/package/kernel/rtl837x/src/rtl837x_mdio.c
+++ b/package/kernel/rtl837x/src/rtl837x_mdio.c
@@ -875,8 +875,18 @@ static int rtl837x_dsa_probe(struct mdio_device *mdiodev)
 	}
 
 #ifdef CONFIG_GPIOLIB
-	if (of_property_read_bool(np, "gpio-controller")) 
-		rtl837x_gpiochip_init(gsw);
+	if (of_property_read_bool(np, "gpio-controller")) {
+		ret = rtl837x_gpiochip_init(gsw);
+		if (ret) {
+			dev_err_probe(dev, ret,
+				      "failed to register GPIO controller\n");
+			rtl837x_dsa_unregister(gsw);
+			if (master)
+				dev_put(master);
+			devm_kfree(dev, gsw);
+			return ret;
+		}
+	}
 #endif /* CONFIG_GPIOLIB */
 
 	rtl837x_sfp_probe(gsw);


### PR DESCRIPTION
## Summary

When the device tree requests `gpio-controller`, `rtl837x_dsa_probe()` calls `rtl837x_gpiochip_init()` but previously ignored its return value. A failed `devm_gpiochip_add_data()` therefore left the DSA switch registered while the requested GPIO provider was unavailable.

Check the return value, unregister the already registered DSA switch, release the Ethernet master reference, and return the original errno. This preserves `-EPROBE_DEFER` and other failures for the driver core. Device trees without `gpio-controller` and successful GPIO registration follow the existing path unchanged.

## Validation

- `git diff --check`
- checkpatch on the proposed diff: no errors or warnings
- No Flint 3 hardware was available for runtime testing

Confidence: 97% based on the local DSA registration/teardown lifecycle and the GPIO provider API contract.

Please verify on hardware or with representative device trees covering:

- no `gpio-controller` property;
- successful GPIO controller registration;
- GPIO registration returning `-EPROBE_DEFER`, `-ENOMEM`, or another error after DSA registration.