### PR TITLE
rtl837x: handle SFP probe errors

### DIFF
--- a/package/kernel/rtl837x/src/rtl837x_mdio.c
+++ b/package/kernel/rtl837x/src/rtl837x_mdio.c
@@ -665,6 +665,8 @@ static int rtl837x_sfp_probe(struct rtk_gsw *gsw)
 	gsw->sfp_bus = bus;
 
 	ret = sfp_bus_add_upstream(bus, gsw, &sfp_ops);
+	if (ret)
+		gsw->sfp_bus = NULL;
 	sfp_bus_put(bus);
 
 	return ret;
@@ -879,7 +881,15 @@ static int rtl837x_dsa_probe(struct mdio_device *mdiodev)
 		rtl837x_gpiochip_init(gsw);
 #endif /* CONFIG_GPIOLIB */
 
-	rtl837x_sfp_probe(gsw);
+	ret = rtl837x_sfp_probe(gsw);
+	if (ret) {
+		dev_err_probe(dev, ret, "failed to attach SFP bus\n");
+		rtl837x_dsa_unregister(gsw);
+		if (master)
+			dev_put(master);
+		devm_kfree(dev, gsw);
+		return ret;
+	}
 
 	rtl837x_debug_proc_init(gsw);
 	rtl837x_status_check_work_init(gsw);


### PR DESCRIPTION
## Summary

Handle failures from the optional SFP bus setup instead of silently continuing with a partially initialized switch.

When an SFP bus is configured but rtl837x_sfp_probe() cannot attach it, the probe now:

- reports the original errno with dev_err_probe();
- unregisters the DSA switch;
- releases the Ethernet master reference;
- returns the error to the driver core.

The no-SFP path remains successful.

The helper also clears gsw->sfp_bus when sfp_bus_add_upstream() fails. The SFP core manages its own bus reference on that failure, while the caller drops the reference returned by sfp_bus_find_fwnode(). Retaining the pointer after a failed add could leave remove() with a stale pointer.

## Why this is correct

The Linux SFP core treats a missing SFP reference as an optional no-bus case, while non-zero results from bus discovery or upstream registration are actual errors. sfp_bus_add_upstream() drops its temporary reference when registration fails, so the driver must not retain the failed bus pointer.

This change is limited to probe error propagation and lifetime cleanup. It does not change SFP capability selection, link modes, or normal attach/detach behavior.

## Validation

- git diff --check
- scripts/checkpatch.pl --no-tree --terse on the patch
- No full OpenWrt build was run because this checkout has no configured .config or target kernel configuration.

## Confidence

97%. The control flow follows the upstream SFP bus reference/error contract. Please verify on hardware or with fault injection that:

1. no SFP property still allows successful probe;
2. a valid SFP bus still attaches and removes normally;
3. an invalid or deferred SFP dependency fails probe with the original errno;
4. an upstream-registration failure does not leave a bus pointer for remove() to use.

This PR is intentionally submitted for maintainer review and runtime validation.