### PR TITLE
rtl837x: report SFP SerDes setup errors

### DIFF
--- a/package/kernel/rtl837x/src/rtl837x_mdio.c
+++ b/package/kernel/rtl837x/src/rtl837x_mdio.c
@@ -592,6 +592,7 @@ static int rtl837x_sfp_module_insert(void *upstream, const struct sfp_eeprom_id 
 {
 	struct rtk_gsw *gsw = upstream;
 	phy_interface_t iface;
+	rtk_api_ret_t ret;
 
 #if LINUX_VERSION_CODE >= KERNEL_VERSION(6,18,0)
 	const struct sfp_module_caps *caps;
@@ -625,7 +626,12 @@ static int rtl837x_sfp_module_insert(void *upstream, const struct sfp_eeprom_id 
 		return -EINVAL;
 	}
 
-	rtk_sdsMode_set(1, gsw->sds1mode);
+	ret = rtk_sdsMode_set(1, gsw->sds1mode);
+	if (ret) {
+		dev_err(gsw->dev, "failed to set SFP SerDes mode: %d\n", ret);
+		return -EIO;
+	}
+
 	return 0;
 }
 


### PR DESCRIPTION
## Summary

Report a SerDes programming failure from the SFP module_insert callback.

The callback previously ignored the result of rtk_sdsMode_set() and returned success even when the switch could not enter the mode selected for the inserted module. It now logs the vendor error and returns -EIO to the SFP core.

## Why this is correct

The Linux SFP core defines module_insert() as the callback used to determine whether an inserted module is supported, and propagates its negative return value. A failed SerDes mode write means the module is not usable by this upstream, so reporting failure prevents the SFP state machine from treating a non-working module as successfully configured.

The selected interface mapping, force-mode behavior, and successful path are unchanged. The vendor API documents RT_ERR_FAILED and RT_ERR_SMI results for rtk_sdsMode_set(); these are converted to the Linux errno expected by the SFP callback.

## Validation

- git diff --check
- scripts/checkpatch.pl --no-tree --terse on the patch
- No full OpenWrt build was run because this checkout has no configured .config or target kernel configuration.

## Confidence

97%. This is a direct error-propagation fix at a callback boundary, supported by the upstream SFP contract and the local Realtek API declaration. Please verify with:

1. a normal supported SFP insertion;
2. an unsupported module;
3. a forced SMI or SerDes programming failure;
4. module removal after a failed insertion.

This PR is intentionally submitted for maintainer review and runtime validation.