### PR TITLE
rtl837x: free debugfs write buffers

### DIFF
--- a/package/kernel/rtl837x/src/rtl837x_dbg.c
+++ b/package/kernel/rtl837x/src/rtl837x_dbg.c
@@ -49,23 +49,29 @@ ssize_t _sdsreg_rw_write(struct file *filep, const char __user *ubuf,
 		return PTR_ERR(buf);
 	
 	if(buf[0] == 'w') {
-		if(sscanf(buf, "w %d %x %x %x", &sds_id, &page, &reg, &val) == -1)
+		if(sscanf(buf, "w %d %x %x %x", &sds_id, &page, &reg, &val) == -1) {
+			kfree(buf);
 			return -EFAULT;
-		else{
+		} else {
 			if (sds_id > 1)
+			{
+				kfree(buf);
 				return -EFAULT;
+			}
 			rtk_rtl8373_sds_reg_write(sds_id, page, reg, val);
 		}
 	} else if(buf[0] == 'r') {
-		if(sscanf(buf, "r %d %x %x", &sds_id, &page, &reg) == -1)
+		if(sscanf(buf, "r %d %x %x", &sds_id, &page, &reg) == -1) {
+			kfree(buf);
 			return -EFAULT;
-		else {
+		} else {
 			rtk_rtl8373_sds_reg_read(sds_id, page, reg, &val);
 			snprintf(_buf_rd_sdsreg, 64, "sds_id: %d, page: 0x%08x, reg: 0x%08x, val: 0x%08x\n", sds_id, page, reg, val);
 		}
 	} else {
 		snprintf(_buf_rd_sdsreg, 64, "echo \"w/r <sds_id> <page> <reg> [<val>]\" > sdsreg\n");
 	}
+	kfree(buf);
 	return count;
 }
 
@@ -80,23 +86,29 @@ ssize_t _phyreg_mmd_rw_write(struct file *filep, const char __user *ubuf,
 		return PTR_ERR(buf);
 	
 	if(buf[0] == 'w') {
-		if(sscanf(buf, "w %d %x %x %x", &port, &devad, &reg, &val) == -1)
+		if(sscanf(buf, "w %d %x %x %x", &port, &devad, &reg, &val) == -1) {
+			kfree(buf);
 			return -EFAULT;
-		else{
+		} else {
 			if (port > 9)
+			{
+				kfree(buf);
 				return -EFAULT;
+			}
 			rtk_port_phyReg_set(1<<port, devad, reg, val);
 		}
 	} else if(buf[0] == 'r') {
-		if(sscanf(buf, "r %d %x %x", &port, &devad, &reg) == -1)
+		if(sscanf(buf, "r %d %x %x", &port, &devad, &reg) == -1) {
+			kfree(buf);
 			return -EFAULT;
-		else {
+		} else {
 			rtk_port_phyReg_get(port, devad, reg, &val);
 			snprintf(_buf_rd_phyreg_mmd, 64, "port: %d, devad: 0x%08x, reg: 0x%08x, val: 0x%08x\n", port, devad, reg, val);
 		}
 	} else {
 		snprintf(_buf_rd_phyreg_mmd, 64, "echo \"w/r <real_port_index> <devad> <reg> [<val>]\" > phyreg_mmd\n");
 	}
+	kfree(buf);
 	return count;
 }
 
@@ -113,20 +125,23 @@ ssize_t _reg_rw_write(struct file *filep, const char __user *ubuf,
 		return PTR_ERR(buf);
 
 	if(buf[0] == 'w') {
-		if(sscanf(buf, "w %x %x", &reg, &val) == -1)
+		if(sscanf(buf, "w %x %x", &reg, &val) == -1) {
+			kfree(buf);
 			return -EFAULT;
-		else
+		} else
 			rtk_rtl8373_setAsicReg(reg, val);
 	} else if(buf[0] == 'r') {
-		if(sscanf(buf, "r %x", &reg) == -1)
+		if(sscanf(buf, "r %x", &reg) == -1) {
+			kfree(buf);
 			return -EFAULT;
-		else {
+		} else {
 			rtk_rtl8373_getAsicReg(reg, &val);
 			snprintf(_buf_rd_reg, 64, "reg: 0x%08x, val: 0x%08x\n", reg, val);
 		}
 	} else {
 		snprintf(_buf_rd_reg, 64, "echo \"w/r <reg> [<val>]\" > reg\n");
 	}
+	kfree(buf);
 	return count;
 }
 


### PR DESCRIPTION
## Summary

Free the user-copy buffers allocated by the three debugfs register write handlers.

_sdsreg_rw_write(), _phyreg_mmd_rw_write(), and _reg_rw_write() each call memdup_user_nul() but previously leaked the returned buffer on every successful write and on several validation-error paths. This patch frees the buffer before every return after a successful allocation.

## Why this is correct

Linux documents memdup_user_nul() as returning a newly allocated user-data copy. The allocation is physically contiguous and must be released with kfree(). The handlers do not retain the buffer after parsing and register access, so freeing it at the end of each path is the correct lifetime.

The patch does not alter register values, accepted command syntax, return values, or the existing debugfs interface. It only closes the allocation lifetime on normal and early-error exits.

## Validation

- git diff --check
- scripts/checkpatch.pl --no-tree --terse on the patch
- Confirmed rtl837x_dbg.o is part of the rtl837x_dsa module
- No full OpenWrt build was run because this checkout has no configured .config or target kernel configuration.

## Confidence

99%. This is a direct allocation/free lifetime fix with no hardware-dependent behavior change. Please review the three write handlers and, if possible, confirm repeated writes do not grow kernel memory usage under kmemleak or slab accounting.