### PR TITLE
rtl837x: validate debugfs command input

### DIFF
--- a/package/kernel/rtl837x/src/rtl837x_dbg.c
+++ b/package/kernel/rtl837x/src/rtl837x_dbg.c
@@ -49,7 +49,7 @@ ssize_t _sdsreg_rw_write(struct file *filep, const char __user *ubuf,
 		return PTR_ERR(buf);
 	
 	if(buf[0] == 'w') {
-		if(sscanf(buf, "w %d %x %x %x", &sds_id, &page, &reg, &val) == -1)
+		if (sscanf(buf, "w %u %x %x %x", &sds_id, &page, &reg, &val) != 4)
 			return -EFAULT;
 		else{
 			if (sds_id > 1)
@@ -57,7 +57,7 @@ ssize_t _sdsreg_rw_write(struct file *filep, const char __user *ubuf,
 			rtk_rtl8373_sds_reg_write(sds_id, page, reg, val);
 		}
 	} else if(buf[0] == 'r') {
-		if(sscanf(buf, "r %d %x %x", &sds_id, &page, &reg) == -1)
+		if (sscanf(buf, "r %u %x %x", &sds_id, &page, &reg) != 3)
 			return -EFAULT;
 		else {
 			rtk_rtl8373_sds_reg_read(sds_id, page, reg, &val);
@@ -80,7 +80,7 @@ ssize_t _phyreg_mmd_rw_write(struct file *filep, const char __user *ubuf,
 		return PTR_ERR(buf);
 	
 	if(buf[0] == 'w') {
-		if(sscanf(buf, "w %d %x %x %x", &port, &devad, &reg, &val) == -1)
+		if (sscanf(buf, "w %u %x %x %x", &port, &devad, &reg, &val) != 4)
 			return -EFAULT;
 		else{
 			if (port > 9)
@@ -88,7 +88,7 @@ ssize_t _phyreg_mmd_rw_write(struct file *filep, const char __user *ubuf,
 			rtk_port_phyReg_set(1<<port, devad, reg, val);
 		}
 	} else if(buf[0] == 'r') {
-		if(sscanf(buf, "r %d %x %x", &port, &devad, &reg) == -1)
+		if (sscanf(buf, "r %u %x %x", &port, &devad, &reg) != 3)
 			return -EFAULT;
 		else {
 			rtk_port_phyReg_get(port, devad, reg, &val);
@@ -113,12 +113,12 @@ ssize_t _reg_rw_write(struct file *filep, const char __user *ubuf,
 		return PTR_ERR(buf);
 
 	if(buf[0] == 'w') {
-		if(sscanf(buf, "w %x %x", &reg, &val) == -1)
+		if (sscanf(buf, "w %x %x", &reg, &val) != 2)
 			return -EFAULT;
 		else
 			rtk_rtl8373_setAsicReg(reg, val);
 	} else if(buf[0] == 'r') {
-		if(sscanf(buf, "r %x", &reg) == -1)
+		if (sscanf(buf, "r %x", &reg) != 1)
 			return -EFAULT;
 		else {
 			rtk_rtl8373_getAsicReg(reg, &val);


### PR DESCRIPTION
## Summary

Validate the number and types of fields parsed by the debugfs register commands.

The three debugfs write handlers previously treated only sscanf() == -1 as a parse failure. Ordinary malformed or truncated input returns the number of successfully assigned fields (0..N), so commands such as "w" or "w 1" could use uninitialized register, page, or value variables. The handlers now require the exact number of fields for each command. The unsigned sds_id and port fields also use %u, matching their uint32_t destinations.

## Why this is correct

sscanf() reports the number of successful assignments; an input error is not the only invalid result. Requiring 4, 3, 2, or 1 assignments for the four command forms prevents register access with uninitialized arguments. This follows established upstream kernel patterns that validate sscanf() against the expected conversion count.

The change preserves the existing accepted command forms and return value for valid input. It only rejects incomplete or malformed commands that were previously processed unsafely.

This patch is intentionally independent of PR #21, which addresses the separate debugfs allocation cleanup.

## Validation

- git diff --check
- scripts/checkpatch.pl --no-tree --terse
- No full OpenWrt build was run because this checkout has no configured .config or target kernel configuration.

## Confidence

99%. The fix is a direct parser-contract correction with no hardware behavior change. Please verify:

1. Valid sdsreg, phyreg_mmd, and reg read/write commands.
2. Empty and partial commands.
3. Out-of-range sds_id and port values.
4. Extra trailing fields, if the intended interface should reject them.

This PR is intentionally submitted for maintainer review and runtime validation.