### PR TITLE
rtl837x: handle CPU port status read errors

### DIFF
--- a/package/kernel/rtl837x/src/rtl837x_mdio.c
+++ b/package/kernel/rtl837x/src/rtl837x_mdio.c
@@ -537,12 +537,19 @@ static void rtl837x_status_check_work_func(struct work_struct *work)
 {
 	struct rtk_gsw *gsw = container_of(work, struct rtk_gsw, status_check_work.work);
 
-	rtk_port_status_t port_status;
+	rtk_port_status_t port_status = { 0 };
+	int ret;
 
 	if (!gsw->ethernet_master)
 		return;
 
-	rtk_port_macStatus_get(gsw->cpu_port, &port_status);
+	ret = rtk_port_macStatus_get(gsw->cpu_port, &port_status);
+	if (ret) {
+		dev_warn_ratelimited(gsw->dev,
+				     "failed to read CPU port status: %d\n", ret);
+		goto reschedule;
+	}
+
 	if (!port_status.link)
 	{
 		if (gsw->cpu_port != UTP_PORT3 && gsw->cpu_port != UTP_PORT8)
@@ -567,6 +574,7 @@ static void rtl837x_status_check_work_func(struct work_struct *work)
 		mdelay(2000);
 	}
 
+reschedule:
 	queue_delayed_work_on(smp_processor_id(), 
 						system_wq, 
 						&gsw->status_check_work, 


### PR DESCRIPTION
## Summary

Handle failures while reading the CPU port status in the periodic SerDes recovery worker.

The worker previously ignored the return value of rtk_port_macStatus_get() and immediately consumed port_status.link. The Realtek DAL can return before populating the output structure when an SMI register read fails, so the worker could make a decision based on an uninitialized value and reset the SerDes spuriously.

On a status read error, the worker now emits a rate-limited warning, skips recovery for that iteration, and schedules the next periodic check. The status structure is also initialized defensively.

## Why this is correct

rtk_port_macStatus_get() explicitly reports SMI and driver errors. In the bundled RTL8373 DAL implementation, every register read is checked and the function returns immediately on failure, before all fields of rtk_port_status_t have been written. Ignoring that result is therefore unsafe.

A failed status read is not evidence that the CPU link is down. Skipping the reset avoids changing hardware state on an unknown status, while requeueing preserves the existing monitoring behavior. Successful reads follow the existing link detection and SerDes recovery path unchanged.

The warning is rate-limited because the worker polls once per second and a persistent SMI failure should not flood the kernel log.

## Validation

- git diff --check
- scripts/checkpatch.pl --no-tree --terse
- Verified the only changed file is package/kernel/rtl837x/src/rtl837x_mdio.c
- No full OpenWrt build was run because this checkout has no configured .config or target kernel configuration.

## Confidence

98%. The bug is directly established by the ignored API error and the DAL early-return behavior. Please verify:

1. Normal CPU link-up polling remains unchanged.
2. A real CPU link-down event still follows the existing SerDes recovery path.
3. Injected or observed SMI/MDIO read failures produce a warning without a SerDes reset.
4. Polling resumes after a transient status read failure.

This PR is intentionally submitted for maintainer review and hardware/runtime validation.