### PR TITLE
rtl837x: report SFP SerDes removal errors

### DIFF
--- a/package/kernel/rtl837x/src/rtl837x_mdio.c
+++ b/package/kernel/rtl837x/src/rtl837x_mdio.c
@@ -632,10 +632,13 @@ static int rtl837x_sfp_module_insert(void *upstream, const struct sfp_eeprom_id 
 static void rtl837x_sfp_module_remove(void *upstream)
 {
 	struct rtk_gsw *gsw = upstream;
+	rtk_api_ret_t ret;
 	dev_info(gsw->dev, "SFP module remove\n");
 
 	USE_SERDESMODE(1, SERDES_OFF);
-	rtk_sdsMode_set(1, gsw->sds1mode);
+	ret = rtk_sdsMode_set(1, gsw->sds1mode);
+	if (ret)
+		dev_err(gsw->dev, "failed to disable SFP SerDes: %d\n", ret);
 }
 
 static const struct sfp_upstream_ops sfp_ops = {


### PR DESCRIPTION
## Summary

Report failures while disabling the SFP SerDes during module removal.

rtl837x_sfp_module_remove() previously ignored the return value of rtk_sdsMode_set(). If the switch rejects the requested SerDes mode or the SMI transaction fails, teardown continues without any diagnostic.

The callback now records the return value and emits a device error when the hardware operation fails. The callback remains non-failing because the upstream SFP API defines module_remove as a void callback.

## Why this is correct

The Realtek API returns a status for rtk_sdsMode_set(), including hardware access failures. Ignoring that status hides a failed state transition and makes runtime diagnosis unnecessarily difficult.

The Linux SFP contract gives module_remove no return channel, so logging is the only non-invasive error reporting available at this boundary. Successful behavior is unchanged, and teardown is not blocked by a module-removal error.

This is the removal-side counterpart to the insertion error reporting proposed in PR #20.

## Validation

- git diff --check
- scripts/checkpatch.pl --no-tree --terse
- Verified the only changed file is package/kernel/rtl837x/src/rtl837x_mdio.c
- No full OpenWrt build was run because this checkout has no configured .config or target kernel configuration.

## Confidence

97%. The return value is a documented part of the Realtek API and the SFP callback cannot propagate an error. Please verify:

1. Removing a working SFP module still disables the configured SerDes mode.
2. An injected or observed SMI/SerDes failure produces the new diagnostic.
3. SFP teardown completes normally even when the hardware transition fails.

This PR is submitted for maintainer review and runtime validation.