### PR TITLE
rtl837x: report FDB flush errors

### DIFF
--- a/package/kernel/rtl837x/src/rtl837x_dsa_ops.c
+++ b/package/kernel/rtl837x/src/rtl837x_dsa_ops.c
@@ -677,6 +677,7 @@ static void rtl837x_port_fast_age(struct dsa_switch *ds, int port)
 {
 	struct rtk_gsw *gsw = ds->priv;
 	rtk_l2_flushCfg_t cfg = { 0 };
+	rtk_api_ret_t ret;
 
 	if (!rtl837x_user_port(gsw, port))
 		return;
@@ -686,7 +687,10 @@ static void rtl837x_port_fast_age(struct dsa_switch *ds, int port)
 	cfg.flushStaticAddr = DISABLED;
 	cfg.flushAddrOnAllPorts = DISABLED;
 
-	rtk_l2_ucastAddr_flush(&cfg);
+	ret = rtk_l2_ucastAddr_flush(&cfg);
+	if (ret)
+		dev_err(gsw->dev, "failed to flush FDB for port %d: %d\n", port,
+			ret);
 }
 
 static int rtl837x_port_vlan_filtering(struct dsa_switch *ds, int port,


### PR DESCRIPTION
## Summary

Report failures from the FDB flush operation used by the DSA fast-age callback.

rtl837x_port_fast_age() previously called rtk_l2_ucastAddr_flush() and discarded its return value. A failed SMI transaction or switch-side operation could therefore leave stale dynamic FDB entries while the kernel received no diagnostic.

The callback now preserves the return value and reports failures with dev_err.

## Why this is correct

The Realtek API declares rtk_l2_ucastAddr_flush() as returning rtk_api_ret_t, with RT_ERR_OK as the success result and hardware/API errors otherwise. The operation is the actual implementation of DSA fast-age for a user port, so a failure is operationally relevant.

The DSA port_fast_age callback is void and cannot report an errno to the bridge/DSA layer. Logging the error is therefore the available non-invasive handling at this boundary. The hardware operation is still attempted exactly as before, and successful behavior is unchanged.

## Validation

- git diff --check
- scripts/checkpatch.pl --no-tree --terse
- Verified the only changed file is package/kernel/rtl837x/src/rtl837x_dsa_ops.c
- No full OpenWrt build was run because this checkout has no configured .config or target kernel configuration.

## Confidence

96%. The API return contract and the DSA callback signature are explicit. Please verify:

1. FDB entries are flushed normally after a port fast-age event.
2. An injected or observed switch/SMI failure emits the new diagnostic.
3. The callback remains safe and non-blocking when the flush fails.

This PR is submitted for maintainer review and runtime validation.