### PR TITLE
rtl837x: report STP state errors

### DIFF
--- a/package/kernel/rtl837x/src/rtl837x_dsa_ops.c
+++ b/package/kernel/rtl837x/src/rtl837x_dsa_ops.c
@@ -657,20 +657,27 @@ static int rtl837x_port_enable(struct dsa_switch *ds, int port,
 static void rtl837x_port_disable(struct dsa_switch *ds, int port)
 {
 	struct rtk_gsw *gsw = ds->priv;
+	int ret;
 
 	if (!rtl837x_valid_port(gsw, port))
 		return;
 
 	gsw->port_enabled[port] = false;
-	rtl837x_set_stp_state(gsw, port, BR_STATE_DISABLED);
+	ret = rtl837x_set_stp_state(gsw, port, BR_STATE_DISABLED);
+	if (ret)
+		dev_err(gsw->dev, "failed to disable port %d: %d\n", port, ret);
 }
 
 static void rtl837x_port_stp_state_set(struct dsa_switch *ds, int port,
 				       u8 state)
 {
 	struct rtk_gsw *gsw = ds->priv;
+	int ret;
 
-	rtl837x_set_stp_state(gsw, port, state);
+	ret = rtl837x_set_stp_state(gsw, port, state);
+	if (ret)
+		dev_err(gsw->dev, "failed to set STP state %u on port %d: %d\n",
+			state, port, ret);
 }
 
 static void rtl837x_port_fast_age(struct dsa_switch *ds, int port)


### PR DESCRIPTION
## Summary

Report failures while programming STP state for DSA ports.

The port_disable and port_stp_state_set callbacks previously discarded the result of rtl837x_set_stp_state(). A failed Realtek register transaction could leave the hardware in its previous forwarding state while the kernel received no diagnostic.

The callbacks now log the returned error together with the affected port and requested state. The existing hardware operation and DSA callback behavior are otherwise unchanged.

## Why this is correct

rtl837x_set_stp_state() converts the Realtek MSTP API result into a Linux error, so its return value is meaningful and must not be silently discarded. The DSA port_disable and port_stp_state_set callbacks are both void, which prevents returning the error to the DSA core; logging is the non-invasive way to expose a hardware/software state mismatch at this boundary.

Successful transitions are unchanged. On failure, the code still attempts the requested operation and reports the failure rather than hiding it.

## Validation

- git diff --check
- scripts/checkpatch.pl --no-tree --terse
- Verified the only changed file is package/kernel/rtl837x/src/rtl837x_dsa_ops.c
- No full OpenWrt build was run because this checkout has no configured .config or target kernel configuration.

## Confidence

96%. The Realtek API return path, Linux error conversion, and DSA callback signatures are explicit. Please verify:

1. Normal port enable/disable and bridge STP transitions.
2. An injected or observed SMI failure produces the new diagnostic.
3. The hardware state is checked after a failed STP write.

This PR is submitted for maintainer review and runtime validation.