### PR TITLE
rtl837x: report SerDes recovery errors

### DIFF
--- a/package/kernel/rtl837x/src/rtl837x_mdio.c
+++ b/package/kernel/rtl837x/src/rtl837x_mdio.c
@@ -538,6 +538,7 @@ static void rtl837x_status_check_work_func(struct work_struct *work)
 	struct rtk_gsw *gsw = container_of(work, struct rtk_gsw, status_check_work.work);
 
 	rtk_port_status_t port_status;
+	int ret;
 
 	if (!gsw->ethernet_master)
 		return;
@@ -556,13 +557,23 @@ static void rtl837x_status_check_work_func(struct work_struct *work)
 		rtnl_lock();
 		dev_close(gsw->ethernet_master);
 		rtnl_unlock();
-		rtk_sdsMode_set(0, SERDES_OFF);
+		ret = rtk_sdsMode_set(0, SERDES_OFF);
+		if (ret)
+			dev_warn_ratelimited(gsw->dev,
+					     "failed to disable CPU SerDes: %d\n", ret);
 		mdelay(200);
 
 		rtnl_lock();
-		dev_open(gsw->ethernet_master, NULL);
+		ret = dev_open(gsw->ethernet_master, NULL);
 		rtnl_unlock();
-		rtk_sdsMode_set(0, gsw->sds0mode);
+		if (ret)
+			dev_warn_ratelimited(gsw->dev,
+					     "failed to reopen ethernet master: %d\n", ret);
+
+		ret = rtk_sdsMode_set(0, gsw->sds0mode);
+		if (ret)
+			dev_warn_ratelimited(gsw->dev,
+					     "failed to restore CPU SerDes mode: %d\n", ret);
 
 		mdelay(2000);
 	}


### PR DESCRIPTION
## Summary

Report failures from the operations used by the CPU SerDes recovery worker.

The worker previously discarded the return values of both rtk_sdsMode_set() calls and of dev_open(). A failed SerDes transition or a failed master reopen could therefore leave the recovery sequence in an unknown state without a diagnostic.

The worker now records and reports these errors with rate limiting. The existing recovery order and successful path are unchanged. dev_close() is intentionally not changed because the Linux API defines it as a void function.

## Why this is correct

The Realtek SerDes API returns rtk_api_ret_t and can report switch/SMI failures. dev_open() returns an errno when the network device cannot be reopened. These results are operationally relevant to this recovery sequence and should not be silently discarded.

The worker has no error return channel, so rate-limited device warnings expose failures while allowing the sequence to continue and attempt the remaining recovery steps. This avoids adding a new policy for retries or reset escalation and preserves the current behavior when operations succeed.

## Validation

- git diff --check
- scripts/checkpatch.pl --no-tree --terse
- Verified the only changed file is package/kernel/rtl837x/src/rtl837x_mdio.c
- No full OpenWrt build was run because this checkout has no configured .config or target kernel configuration.

## Confidence

95%. The return types and error paths are explicit, and the patch does not alter the successful recovery sequence. Please verify:

1. Normal CPU link recovery remains unchanged.
2. An SMI/SerDes failure is reported by the new warnings.
3. A failed master reopen is reported and the final SerDes restore is still attempted.
4. The worker continues polling after transient failures.

This PR is submitted for maintainer review and hardware/runtime validation.