### PR TITLE
rtl837x: clear global private state on teardown

### DIFF
--- a/package/kernel/rtl837x/src/rtl837x_mdio.c
+++ b/package/kernel/rtl837x/src/rtl837x_mdio.c
@@ -729,6 +729,12 @@ static const struct of_device_id rtk_gsw_match[] = {
 
 MODULE_DEVICE_TABLE(of, rtk_gsw_match);
 
+static void rtl837x_clear_global_priv(struct rtk_gsw *gsw)
+{
+	if (rtl_gbl_priv == gsw)
+		rtl_gbl_priv = NULL;
+}
+
 static int rtl837x_dsa_probe(struct mdio_device *mdiodev)
 {
 	struct device *dev =&mdiodev->dev;
@@ -856,6 +862,7 @@ static int rtl837x_dsa_probe(struct mdio_device *mdiodev)
 	if (ret)
 	{
 		dev_err(gsw->dev, "rtl8372n_hw_init failed, ret=%d\n",ret);
+		rtl837x_clear_global_priv(gsw);
 		if (master)
 			dev_put(master);
 		devm_kfree(dev, gsw);
@@ -868,6 +875,7 @@ static int rtl837x_dsa_probe(struct mdio_device *mdiodev)
 	ret = rtl837x_dsa_register(gsw);
 	if (ret){
 		dev_err(gsw->dev, "rtl837x_dsa_register failed, ret=%d\n", ret);
+		rtl837x_clear_global_priv(gsw);
 		if (master)
 			dev_put(master);
 		devm_kfree(dev, gsw);
@@ -903,6 +911,7 @@ static void rtl837x_dsa_remove(struct mdio_device *mdiodev)
 		dev_put(gsw->ethernet_master);
 		gsw->ethernet_master = NULL;
 	}
+	rtl837x_clear_global_priv(gsw);
 }
 
 static void rtl837x_mdio_shutdown(struct mdio_device *mdiodev)


### PR DESCRIPTION
## Summary

Clear `rtl_gbl_priv` when probe fails after publishing the switch context and when the MDIO device is removed.

## Why this is correct

The Realtek ASIC accessors in `rtk-api/dal/rtl8373/rtl8373_asicdrv.c` dereference `rtl_gbl_priv->map` directly. `rtl837x_dsa_probe()` assigns `rtl_gbl_priv = gsw` before `rtl8372n_hw_init()` and before DSA registration. If either stage fails, the probe path frees `gsw` but previously left the global pointing at that freed object. The normal remove path also completed teardown without clearing it.

The helper uses an identity check before clearing. This keeps a cleanup path from erasing a newer global value if another instance has already published its context. It is called only after all remaining teardown operations that can use the vendor API, and before the failed probe object is freed.

## Scope

This is a lifecycle-only cleanup. It does not change register programming, DSA behavior, or the successful probe path.

## Validation

- `git diff --check`
- `scripts/checkpatch.pl --no-tree --terse`
- Static review of every assignment and use of `rtl_gbl_priv` in the driver and ASIC accessors

No hardware or full OpenWrt build was available in this environment.

## Maintainer verification requested

Please review the global-state lifetime and verify probe failure/rebind scenarios, especially an `rtl8372n_hw_init()` failure followed by another probe and a normal unbind/rebind cycle. I estimate 93% confidence: the stale-pointer lifetime defect and cleanup ordering are clear from the source, while the exact multi-instance expectations of the vendor API should be confirmed by maintainers.