### PR TITLE
rtl837x: handle SerDes swap configuration errors

### DIFF
--- a/package/kernel/rtl837x/src/rtl837x_mdio.c
+++ b/package/kernel/rtl837x/src/rtl837x_mdio.c
@@ -463,16 +463,16 @@ int rtl8372n_hw_init(struct rtk_gsw *gsw, rtl837x_pnswap_cfg_t swap_cfg)
 		ret = gsw->pMapper->rtl8373_sds_regbits_write(
 			0, 0, 0, 0x200, 1);
 		if (ret) {
-			dev_err(gsw->dev,
-				"SDS0 RX PN swap configuration failed, error:%d\n", ret);
-			return -EPERM;
+			dev_warn(gsw->dev,
+				 "SDS0 RX PN swap configuration failed, continuing, error:%d\n",
+				 ret);
 		}
 
 		ret = gsw->pMapper->rtl8373_sds_regbits_write(0, 6, 2, 0x2000, 1);
 		if (ret) {
-			dev_err(gsw->dev,
-				"SDS0 RX PN swap configuration failed, error:%d\n", ret);
-			return -EPERM;
+			dev_warn(gsw->dev,
+				 "SDS0 RX PN swap configuration failed, continuing, error:%d\n",
+				 ret);
 		}
 	}
 
@@ -482,16 +482,16 @@ int rtl8372n_hw_init(struct rtk_gsw *gsw, rtl837x_pnswap_cfg_t swap_cfg)
 		ret = gsw->pMapper->rtl8373_sds_regbits_write(
 			0, 0, 0, 1 << 8, 1);
 		if (ret) {
-			dev_err(gsw->dev,
-				"SDS0 TX PN swap configuration failed, error:%d\n", ret);
-			return -EPERM;
+			dev_warn(gsw->dev,
+				 "SDS0 TX PN swap configuration failed, continuing, error:%d\n",
+				 ret);
 		}
 
 		ret = gsw->pMapper->rtl8373_sds_regbits_write(0, 6, 2, 1 << 14, 1);
 		if (ret) {
-			dev_err(gsw->dev,
-				"SDS0 TX PN swap configuration failed, error:%d\n", ret);
-			return -EPERM;
+			dev_warn(gsw->dev,
+				 "SDS0 TX PN swap configuration failed, continuing, error:%d\n",
+				 ret);
 		}
 	}
 
@@ -501,16 +501,16 @@ int rtl8372n_hw_init(struct rtk_gsw *gsw, rtl837x_pnswap_cfg_t swap_cfg)
 		ret = gsw->pMapper->rtl8373_sds_regbits_write(
 			1, 0, 0, 0x200, 1);
 		if (ret) {
-			dev_err(gsw->dev,
-				"SDS1 RX PN swap configuration failed, error:%d\n", ret);
-			return -EPERM;
+			dev_warn(gsw->dev,
+				 "SDS1 RX PN swap configuration failed, continuing, error:%d\n",
+				 ret);
 		}
 
 		ret = gsw->pMapper->rtl8373_sds_regbits_write(1, 6, 2, 0x2000, 1);
 		if (ret) {
-			dev_err(gsw->dev,
-				"SDS1 RX PN swap configuration failed, error:%d\n", ret);
-			return -EPERM;
+			dev_warn(gsw->dev,
+				 "SDS1 RX PN swap configuration failed, continuing, error:%d\n",
+				 ret);
 		}
 	}
 
@@ -520,16 +520,16 @@ int rtl8372n_hw_init(struct rtk_gsw *gsw, rtl837x_pnswap_cfg_t swap_cfg)
 		ret = gsw->pMapper->rtl8373_sds_regbits_write(
 			1, 0, 0, 1 << 8, 1);
 		if (ret) {
-			dev_err(gsw->dev,
-				"SDS1 TX PN swap configuration failed, error:%d\n", ret);
-			return -EPERM;
+			dev_warn(gsw->dev,
+				 "SDS1 TX PN swap configuration failed, continuing, error:%d\n",
+				 ret);
 		}
 
 		ret = gsw->pMapper->rtl8373_sds_regbits_write(1, 6, 2, 1 << 14, 1);
 		if (ret) {
-			dev_err(gsw->dev,
-				"SDS1 TX PN swap configuration failed, error:%d\n", ret);
-			return -EPERM;
+			dev_warn(gsw->dev,
+				 "SDS1 TX PN swap configuration failed, continuing, error:%d\n",
+				 ret);
 		}
 	}
 
@@ -538,9 +538,9 @@ int rtl8372n_hw_init(struct rtk_gsw *gsw, rtl837x_pnswap_cfg_t swap_cfg)
 		ret = gsw->pMapper->rtl8373_setAsicRegBits(
 			RTL8373_CFG_PHY_MDI_REVERSE_ADDR, 0xF, 0xC);
 		if (ret) {
-			dev_err(gsw->dev,
-				"PHY MDI reverse configuration failed, error:%d\n", ret);
-			return -EPERM;
+			dev_warn(gsw->dev,
+				 "PHY MDI reverse configuration failed, continuing, error:%d\n",
+				 ret);
 		}
 	}
 
@@ -549,9 +549,9 @@ int rtl8372n_hw_init(struct rtk_gsw *gsw, rtl837x_pnswap_cfg_t swap_cfg)
 		ret = gsw->pMapper->rtl8373_setAsicRegBits(
 			RTL8373_CFG_PHY_TX_POLARITY_SWAP_ADDR, 0xFFFF, 0x596A);
 		if (ret) {
-			dev_err(gsw->dev,
-				"PHY TX polarity swap configuration failed, error:%d\n", ret);
-			return -EPERM;
+			dev_warn(gsw->dev,
+				 "PHY TX polarity swap configuration failed, continuing, error:%d\n",
+				 ret);
 		}
 	}
 

--- a/package/kernel/rtl837x/src/rtl837x_mdio.c
+++ b/package/kernel/rtl837x/src/rtl837x_mdio.c
@@ -459,34 +459,101 @@ int rtl8372n_hw_init(struct rtk_gsw *gsw, rtl837x_pnswap_cfg_t swap_cfg)
     // 		page6 reg2 bit14:1
 	if (swap_cfg.sds0_rx_swap)
 	{
-		gsw->pMapper->rtl8373_sds_regbits_write(0, 0, 0, 0x200, 1); //#SDS0RX PN swap
-		gsw->pMapper->rtl8373_sds_regbits_write(0, 6, 2, 0x2000, 1);
+		/* SDS0 RX PN swap */
+		ret = gsw->pMapper->rtl8373_sds_regbits_write(
+			0, 0, 0, 0x200, 1);
+		if (ret) {
+			dev_err(gsw->dev,
+				"SDS0 RX PN swap configuration failed, error:%d\n", ret);
+			return -EPERM;
+		}
+
+		ret = gsw->pMapper->rtl8373_sds_regbits_write(0, 6, 2, 0x2000, 1);
+		if (ret) {
+			dev_err(gsw->dev,
+				"SDS0 RX PN swap configuration failed, error:%d\n", ret);
+			return -EPERM;
+		}
 	}
 
 	if (swap_cfg.sds0_tx_swap)
 	{
-		gsw->pMapper->rtl8373_sds_regbits_write(0, 0, 0, 1 << 8, 1); //#SDS0RTX PN swap
-		gsw->pMapper->rtl8373_sds_regbits_write(0, 6, 2, 1 << 14, 1);
+		/* SDS0 TX PN swap */
+		ret = gsw->pMapper->rtl8373_sds_regbits_write(
+			0, 0, 0, 1 << 8, 1);
+		if (ret) {
+			dev_err(gsw->dev,
+				"SDS0 TX PN swap configuration failed, error:%d\n", ret);
+			return -EPERM;
+		}
+
+		ret = gsw->pMapper->rtl8373_sds_regbits_write(0, 6, 2, 1 << 14, 1);
+		if (ret) {
+			dev_err(gsw->dev,
+				"SDS0 TX PN swap configuration failed, error:%d\n", ret);
+			return -EPERM;
+		}
 	}
 
 	if (swap_cfg.sds1_rx_swap)
 	{
-		gsw->pMapper->rtl8373_sds_regbits_write(1, 0, 0, 0x200, 1); //#SDS1RX PN swap
-		gsw->pMapper->rtl8373_sds_regbits_write(1, 6, 2, 0x2000, 1);
+		/* SDS1 RX PN swap */
+		ret = gsw->pMapper->rtl8373_sds_regbits_write(
+			1, 0, 0, 0x200, 1);
+		if (ret) {
+			dev_err(gsw->dev,
+				"SDS1 RX PN swap configuration failed, error:%d\n", ret);
+			return -EPERM;
+		}
+
+		ret = gsw->pMapper->rtl8373_sds_regbits_write(1, 6, 2, 0x2000, 1);
+		if (ret) {
+			dev_err(gsw->dev,
+				"SDS1 RX PN swap configuration failed, error:%d\n", ret);
+			return -EPERM;
+		}
 	}
 
 	if (swap_cfg.sds1_tx_swap)
 	{
-		gsw->pMapper->rtl8373_sds_regbits_write(1, 0, 0, 1 << 8, 1); //#SDS1TX PN swap
-		gsw->pMapper->rtl8373_sds_regbits_write(1, 6, 2, 1 << 14, 1);
+		/* SDS1 TX PN swap */
+		ret = gsw->pMapper->rtl8373_sds_regbits_write(
+			1, 0, 0, 1 << 8, 1);
+		if (ret) {
+			dev_err(gsw->dev,
+				"SDS1 TX PN swap configuration failed, error:%d\n", ret);
+			return -EPERM;
+		}
+
+		ret = gsw->pMapper->rtl8373_sds_regbits_write(1, 6, 2, 1 << 14, 1);
+		if (ret) {
+			dev_err(gsw->dev,
+				"SDS1 TX PN swap configuration failed, error:%d\n", ret);
+			return -EPERM;
+		}
 	}
 
     // ##MDI reverse configuration for Demo Tap UP RJ45, RTL8366U/RTL8373N/RTL8372N
-	if (swap_cfg.phy_mdi_reverse)
-		gsw->pMapper->rtl8373_setAsicRegBits(RTL8373_CFG_PHY_MDI_REVERSE_ADDR, 0xF, 0xC);
+	if (swap_cfg.phy_mdi_reverse) {
+		ret = gsw->pMapper->rtl8373_setAsicRegBits(
+			RTL8373_CFG_PHY_MDI_REVERSE_ADDR, 0xF, 0xC);
+		if (ret) {
+			dev_err(gsw->dev,
+				"PHY MDI reverse configuration failed, error:%d\n", ret);
+			return -EPERM;
+		}
+	}
 
-	if (swap_cfg.phy_tx_polarity_swap)
-    	gsw->pMapper->rtl8373_setAsicRegBits(RTL8373_CFG_PHY_TX_POLARITY_SWAP_ADDR, 0xFFFF, 0x596A); //#TX_POLARITY_SWAP
+	if (swap_cfg.phy_tx_polarity_swap) {
+		/* PHY TX polarity swap */
+		ret = gsw->pMapper->rtl8373_setAsicRegBits(
+			RTL8373_CFG_PHY_TX_POLARITY_SWAP_ADDR, 0xFFFF, 0x596A);
+		if (ret) {
+			dev_err(gsw->dev,
+				"PHY TX polarity swap configuration failed, error:%d\n", ret);
+			return -EPERM;
+		}
+	}
 
 	ret = rtk_switch_init();
 	if(ret){

--- a/package/kernel/rtl837x/src/rtl837x_mdio.c
+++ b/package/kernel/rtl837x/src/rtl837x_mdio.c
@@ -374,7 +374,7 @@ static int rtl837x_sdsmode(const char *name, rtk_sds_mode_t *mode)
 static int rtl8372n_igmp_init(struct rtk_gsw *gsw)
 {
 
-	unsigned int ret;
+	int ret;
 	ret = rtk_igmp_init();
 	if (ret) return ret;
 
@@ -471,7 +471,7 @@ int rtl8372n_hw_init(struct rtk_gsw *gsw, rtl837x_pnswap_cfg_t swap_cfg)
 		ret = gsw->pMapper->rtl8373_sds_regbits_write(0, 6, 2, 0x2000, 1);
 		if (ret) {
 			dev_warn(gsw->dev,
-				 "SDS0 RX PN swap configuration failed, continuing, error:%d\n",
+				 "SDS0 RX PN swap page 6 configuration failed, continuing, error:%d\n",
 				 ret);
 		}
 	}
@@ -490,7 +490,7 @@ int rtl8372n_hw_init(struct rtk_gsw *gsw, rtl837x_pnswap_cfg_t swap_cfg)
 		ret = gsw->pMapper->rtl8373_sds_regbits_write(0, 6, 2, 1 << 14, 1);
 		if (ret) {
 			dev_warn(gsw->dev,
-				 "SDS0 TX PN swap configuration failed, continuing, error:%d\n",
+				 "SDS0 TX PN swap page 6 configuration failed, continuing, error:%d\n",
 				 ret);
 		}
 	}
@@ -509,7 +509,7 @@ int rtl8372n_hw_init(struct rtk_gsw *gsw, rtl837x_pnswap_cfg_t swap_cfg)
 		ret = gsw->pMapper->rtl8373_sds_regbits_write(1, 6, 2, 0x2000, 1);
 		if (ret) {
 			dev_warn(gsw->dev,
-				 "SDS1 RX PN swap configuration failed, continuing, error:%d\n",
+				 "SDS1 RX PN swap page 6 configuration failed, continuing, error:%d\n",
 				 ret);
 		}
 	}
@@ -528,7 +528,7 @@ int rtl8372n_hw_init(struct rtk_gsw *gsw, rtl837x_pnswap_cfg_t swap_cfg)
 		ret = gsw->pMapper->rtl8373_sds_regbits_write(1, 6, 2, 1 << 14, 1);
 		if (ret) {
 			dev_warn(gsw->dev,
-				 "SDS1 TX PN swap configuration failed, continuing, error:%d\n",
+				 "SDS1 TX PN swap page 6 configuration failed, continuing, error:%d\n",
 				 ret);
 		}
 	}


### PR DESCRIPTION
## Summary

Check all optional SerDes and PHY swap writes during `rtl8372n_hw_init()` and report failures without making the whole switch probe fatal.

The covered operations are the SDS0/SDS1 RX/TX PN-swap pairs, PHY MDI reverse, and PHY TX polarity swap.

## Why this is correct

The mapper and DAL declare these operations as status-returning SMI/MDIO accesses, so failures are real hardware-access errors rather than fire-and-forget calls. The previous code discarded those statuses, making a degraded board-specific configuration invisible.

These writes occur immediately after hardware reset, where early SMI access is known to be transient on this device. Following the maintainer requested policy, failures are reported with `dev_warn()` and initialization continues. This preserves the existing best-effort probe behavior and prevents a transient optional swap write from becoming `-ENODEV` and permanently taking down the LAN path. Each member of an SDS pair is still attempted, and the warning identifies the lane, direction, and page-specific operation that failed.

Mandatory `rtk_switch_init()`, VLAN, IGMP, and other data-path initialization failures retain their existing fail-fast behavior. This patch does not claim transactional rollback for a pair; it makes a partial configuration visible while preserving the established boot semantics.

## Validation

- `git diff --check`: passed.
- `scripts/checkpatch.pl --no-tree --terse`: passed.
- Rebased directly onto the current `flint3-be9300` tip.
- Cross-checked mapper return types and the DAL SMI access paths.

No Flint 3 hardware was available, so warning-level choice and degraded-link behavior remain requested maintainer validation.

Please verify a normal BE9300 boot, an early transient SMI failure, and the resulting SerDes and link behavior.
