### PR TITLE
rtl837x: report CPU tag teardown errors

### DIFF
--- a/package/kernel/rtl837x/src/rtl837x_dsa_ops.c
+++ b/package/kernel/rtl837x/src/rtl837x_dsa_ops.c
@@ -342,12 +342,16 @@ static int rtl837x_setup(struct dsa_switch *ds)
 
 static void rtl837x_teardown(struct dsa_switch *ds)
 {
+	int ret;
+
 	rtnl_lock();
 	dsa_tag_8021q_unregister(ds);
 	rtnl_unlock();
 
 	rtl837x_mdio_teardown(ds);
-	rtk_cpuTag_enable_set(EXTERNAL_CPU, DISABLED);
+	ret = rtk_cpuTag_enable_set(EXTERNAL_CPU, DISABLED);
+	if (ret)
+		dev_err(ds->dev, "failed to disable CPU tag during teardown: %d\n", ret);
 }
 
 static int rtl837x_mdio_read_c45(struct mii_bus *bus, int port, int devad,


### PR DESCRIPTION
## Summary

Report failures from the CPU-tag disable operation in the DSA teardown callback.

## Why this is correct

`rtk_cpuTag_enable_set(EXTERNAL_CPU, DISABLED)` is a status-returning Realtek API. Its documented return values include SMI access failures, invalid input, and driver errors. The setup path already treats the same operation as mandatory and aborts on failure; teardown currently discards the status because the DSA callback itself is `void`.

This patch preserves the `void` callback contract and does not change teardown control flow. It only emits an error when the hardware cannot be left with the proprietary CPU tag disabled, so a failed cleanup is diagnosable instead of silent.

## Validation

- `git diff --check`
- `scripts/checkpatch.pl --no-tree --terse`
- Compared the teardown call with the checked setup call and the Realtek `cpuTag` API declaration/implementation

No hardware or full OpenWrt build was available in this environment.

## Maintainer verification requested

Please verify whether the CPU-tag disable is required after `rtl837x_mdio_teardown()` on all supported chips and, if possible, exercise unbind/rebind with an injected SMI failure. I estimate 96% confidence: the call returns an explicit error and the DSA callback cannot propagate it, so logging is the least invasive correct handling.