### PR TITLE
rtl837x: handle debugfs SerDes dump errors

### DIFF
--- a/package/kernel/rtl837x/src/rtl837x_dbg.c
+++ b/package/kernel/rtl837x/src/rtl837x_dbg.c
@@ -142,51 +142,99 @@ static ssize_t _sds_page_dump_read(struct file *filep, char __user *ubuf,
 	if (!buf)
 		return -ENOMEM;
 
-	rtk_rtl8373_getAsicReg(RTL8373_SDS_MODE_SEL_ADDR, &v3);
+	ret = rtk_rtl8373_getAsicReg(RTL8373_SDS_MODE_SEL_ADDR, &v3);
+	if (ret)
+		goto out_error;
 	len += snprintf(buf + len, 4096 - len, "reg 0x7b20: %#x\n", v3);
-	rtk_rtl8373_sds_reg_read(0, 0x21, 0x10, &v3);
+	ret = rtk_rtl8373_sds_reg_read(0, 0x21, 0x10, &v3);
+	if (ret)
+		goto out_error;
 	len += snprintf(buf + len, 4096 - len, "sds page 0x21  reg 0x10; data = %#x\n", v3);
-	rtk_rtl8373_sds_reg_read(0, 0x21, 0x13, &v3);
+	ret = rtk_rtl8373_sds_reg_read(0, 0x21, 0x13, &v3);
+	if (ret)
+		goto out_error;
 	len += snprintf(buf + len, 4096 - len, "sds page 0x21  reg 0x13; data = %#x\n", v3);
-	rtk_rtl8373_sds_reg_read(0, 0x21, 0x18, &v3);
+	ret = rtk_rtl8373_sds_reg_read(0, 0x21, 0x18, &v3);
+	if (ret)
+		goto out_error;
 	len += snprintf(buf + len, 4096 - len, "sds page 0x21  reg 0x18; data = %#x\n", v3);
-	rtk_rtl8373_sds_reg_read(0, 0x21, 0x1B, &v3);
+	ret = rtk_rtl8373_sds_reg_read(0, 0x21, 0x1B, &v3);
+	if (ret)
+		goto out_error;
 	len += snprintf(buf + len, 4096 - len, "sds page 0x21  reg 0x1b; data = %#x\n", v3);
-	rtk_rtl8373_sds_reg_read(0, 0x21, 0x1D, &v3);
+	ret = rtk_rtl8373_sds_reg_read(0, 0x21, 0x1D, &v3);
+	if (ret)
+		goto out_error;
 	len += snprintf(buf + len, 4096 - len, "sds page 0x21  reg 0x1d; data = %#x\n", v3);
-	rtk_rtl8373_sds_reg_read(0, 0x36, 0x1C, &v3);
+	ret = rtk_rtl8373_sds_reg_read(0, 0x36, 0x1C, &v3);
+	if (ret)
+		goto out_error;
 	len += snprintf(buf + len, 4096 - len, "sds page 0x36  reg 0x1c; data = %#x\n", v3);
-	rtk_rtl8373_sds_reg_read(0, 0x36, 0x14, &v3);
+	ret = rtk_rtl8373_sds_reg_read(0, 0x36, 0x14, &v3);
+	if (ret)
+		goto out_error;
 	len += snprintf(buf + len, 4096 - len, "sds page 0x36  reg 0x14; data = %#x\n", v3);
-	rtk_rtl8373_sds_reg_read(0, 0x36, 0x10, &v3);
+	ret = rtk_rtl8373_sds_reg_read(0, 0x36, 0x10, &v3);
+	if (ret)
+		goto out_error;
 	len += snprintf(buf + len, 4096 - len, "sds page 0x36  reg 0x10; data = %#x\n", v3);
-	rtk_rtl8373_sds_reg_read(0, 0x2E, 4, &v3);
+	ret = rtk_rtl8373_sds_reg_read(0, 0x2E, 4, &v3);
+	if (ret)
+		goto out_error;
 	len += snprintf(buf + len, 4096 - len, "sds page 0x2e  reg 0x04; data = %#x\n", v3);
-	rtk_rtl8373_sds_reg_read(0, 0x2E, 6, &v3);
+	ret = rtk_rtl8373_sds_reg_read(0, 0x2E, 6, &v3);
+	if (ret)
+		goto out_error;
 	len += snprintf(buf + len, 4096 - len, "sds page 0x2e  reg 0x06; data = %#x\n", v3);
-	rtk_rtl8373_sds_reg_read(0, 0x2E, 7, &v3);
+	ret = rtk_rtl8373_sds_reg_read(0, 0x2E, 7, &v3);
+	if (ret)
+		goto out_error;
 	len += snprintf(buf + len, 4096 - len, "sds page 0x2e  reg 0x07; data = %#x\n", v3);
-	rtk_rtl8373_sds_reg_read(0, 0x2E, 9, &v3);
+	ret = rtk_rtl8373_sds_reg_read(0, 0x2E, 9, &v3);
+	if (ret)
+		goto out_error;
 	len += snprintf(buf + len, 4096 - len, "sds page 0x2e  reg 0x09; data = %#x\n", v3);
-	rtk_rtl8373_sds_reg_read(0, 0x2E, 0xB, &v3);
+	ret = rtk_rtl8373_sds_reg_read(0, 0x2E, 0xB, &v3);
+	if (ret)
+		goto out_error;
 	len += snprintf(buf + len, 4096 - len, "sds page 0x2e  reg 0x0b; data = %#x\n", v3);
-	rtk_rtl8373_sds_reg_read(0, 0x2E, 0xC, &v3);
+	ret = rtk_rtl8373_sds_reg_read(0, 0x2E, 0xC, &v3);
+	if (ret)
+		goto out_error;
 	len += snprintf(buf + len, 4096 - len, "sds page 0x2e  reg 0x0c; data = %#x\n", v3);
-	rtk_rtl8373_sds_reg_read(0, 0x2E, 0xD, &v3);
+	ret = rtk_rtl8373_sds_reg_read(0, 0x2E, 0xD, &v3);
+	if (ret)
+		goto out_error;
 	len += snprintf(buf + len, 4096 - len, "sds page 0x2e  reg 0x0d; data = %#x\n", v3);
-	rtk_rtl8373_sds_reg_read(0, 0x2E, 0x15, &v3);
+	ret = rtk_rtl8373_sds_reg_read(0, 0x2E, 0x15, &v3);
+	if (ret)
+		goto out_error;
 	len += snprintf(buf + len, 4096 - len, "sds page 0x2e  reg 0x15; data = %#x\n", v3);
-	rtk_rtl8373_sds_reg_read(0, 0x2E, 0x16, &v3);
+	ret = rtk_rtl8373_sds_reg_read(0, 0x2E, 0x16, &v3);
+	if (ret)
+		goto out_error;
 	len += snprintf(buf + len, 4096 - len, "sds page 0x2e  reg 0x16; data = %#x\n", v3);
-	rtk_rtl8373_sds_reg_read(0, 0x2E, 0x1D, &v3);
+	ret = rtk_rtl8373_sds_reg_read(0, 0x2E, 0x1D, &v3);
+	if (ret)
+		goto out_error;
 	len += snprintf(buf + len, 4096 - len, "sds page 0x2e  reg 0x1d; data = %#x\n", v3);
 
-	rtk_rtl8373_sds_regbits_read(0, 5, 0, 1, &v3);
+	ret = rtk_rtl8373_sds_regbits_read(0, 5, 0, 1, &v3);
+	if (ret)
+		goto out_error;
 	len += snprintf(buf + len, 4096 - len, "sds page 5  reg 0; bit0 = %#x\n", v3);
-	rtk_rtl8373_sds_regbits_read(0, 5, 1, 255, &v3);
+	ret = rtk_rtl8373_sds_regbits_read(0, 5, 1, 255, &v3);
+	if (ret)
+		goto out_error;
 	len += snprintf(buf + len, 4096 - len, "sds page 5  reg 1; bit7:0 = %#x\n", v3);
 
 	ret = simple_read_from_buffer(ubuf, count, offp, buf, len);
+	goto out;
+
+out_error:
+	ret = -EIO;
+
+out:
 	kfree(buf);
 
 	return ret;


### PR DESCRIPTION
## Summary

Stop the debugfs SerDes page dump when any underlying register read fails.

## Why this is correct

`_sds_page_dump_read()` performs 21 Realtek register/bit reads and previously ignored every return value. The vendor APIs return status codes for SMI failures and may leave the output argument unchanged when a read fails. The handler then formatted `v3` as if the read had succeeded, so the dump could contain stale or uninitialized data and appear valid.

This patch checks each status before formatting its value. On failure it frees the temporary 4096-byte buffer and returns `-EIO`, which is the appropriate result for a debugfs read backed by a failed hardware transaction. The successful dump content and ordering are unchanged.

## Scope

Only the `sds_page_dump` read path is changed. The separate debugfs write-buffer and command-parser fixes are intentionally left to PRs #21 and #22.

## Validation

- `git diff --check`
- `scripts/checkpatch.pl --no-tree --terse`
- Static review of all 21 calls in the dump handler against the status-returning Realtek API declarations and implementations

No hardware or full OpenWrt build was available in this environment.

## Maintainer verification requested

Please exercise the dump with a healthy switch and with an injected/observed SMI failure at several read positions, confirming that success output is unchanged and failure returns `-EIO` without a partial misleading dump. I estimate 95% confidence: the ignored status values and cleanup path are directly visible in source; only the preferred user-facing debugfs error presentation needs maintainer confirmation.