### PR TITLE
rtl837x: reject malformed extra-init properties

### DIFF
--- a/package/kernel/rtl837x/src/rtl837x_mdio.c
+++ b/package/kernel/rtl837x/src/rtl837x_mdio.c
@@ -10,6 +10,7 @@
 #include <linux/bits.h>
 #include <linux/device.h>
 #include <linux/delay.h>
+#include <linux/of.h>
 #include <linux/of_mdio.h>
 #include <linux/of_gpio.h>
 #include <linux/of_net.h>
@@ -380,7 +381,14 @@ static int of_extra_init(struct rtk_gsw *gsw)
 	list = of_get_property(node, "extra-init", &size);
 	if (!list || !size) return 0;
 
-	data_len = size / (3*sizeof(__be32));
+	data_len = of_property_count_elems_of_size(node, "extra-init",
+						  3 * sizeof(*list));
+	if (data_len < 0) {
+		dev_err(gsw->dev,
+			"invalid extra-init property length: %d bytes\n", size);
+		return data_len;
+	}
+
 	for (int i=0; i<data_len; i++)
 	{
 		reg = be32_to_cpu(*list);


### PR DESCRIPTION
## Summary

Reject malformed `extra-init` Device Tree properties whose byte length is not an exact multiple of one register/mask/value tuple.

The current code calculates the tuple count with integer division. A property with one or two trailing cells is therefore accepted and the trailing data is silently ignored. A property shorter than one tuple is also treated as a successful no-op.

## Why this solution is correct

* The driver consumes `extra-init` as repeated triples of 32-bit big-endian cells: register, mask, and value.
* `of_property_count_elems_of_size()` is the kernel Device Tree helper for requiring a property length to be aligned to a requested element size.
* The property is optional, so the existing absent/empty-property fast path is preserved.
* A valid property produces the same tuple count and the same register writes as before.
* A malformed property now returns the kernel helper error and stops hardware initialization before applying a partial configuration.
* This is independent of the write-error propagation in PR #12: that PR handles failures after a tuple has been decoded, while this patch validates the tuple container itself.

## Validation

* `git diff --check`
* `scripts/checkpatch.pl --no-tree --terse`
* Cross-checked the helper semantics against the Linux OF implementation.
* No Flint 3 hardware or full OpenWrt build was available on this macOS host.

## Requested review

Please confirm that the intended `extra-init` ABI is exactly a sequence of register/mask/value triples and that rejecting a malformed property is preferable to silently ignoring its trailing cells. If this is accepted, please also test one valid tuple and one malformed property with a trailing cell using a test DTB or an equivalent fault-injection path.

## Confidence

Approximately 93% for the parsing and failure-path correction. The valid-property behavior is unchanged and the change uses the standard kernel helper. The remaining point for maintainer confirmation is whether any external DTS/DTB intentionally relies on non-tuple trailing data.