### PR TITLE
rtl837x: report device ID read failures

### DIFF
--- a/package/kernel/rtl837x/src/rtl837x_mdio.c
+++ b/package/kernel/rtl837x/src/rtl837x_mdio.c
@@ -269,7 +269,15 @@ static int rtl837x_switch_probe(struct rtk_gsw *gsw)
 CHIP_NOT_SUPPORTED:
 	//未知芯片ID
 	rtk_uint32 regValue;
-	rtl8373_getAsicReg(0x4, &regValue);
+	rtk_api_ret_t ret;
+
+	ret = rtl8373_getAsicReg(0x4, &regValue);
+	if (ret != RT_ERR_OK) {
+		dev_err(gsw->dev,
+			"Error: Can not read device ID, error:%d\n", ret);
+		return ret;
+	}
+
 	dev_err(gsw->dev, "Error: Can not support this device, devid 0x%x\n", regValue);
 	return RT_ERR_CHIP_NOT_SUPPORTED;
 


### PR DESCRIPTION
## Summary

Handle the second device-ID read in the unsupported-chip path.

When all retry attempts in `rtl837x_switch_probe()` fail, the fallback reads register `0x4) to include the device ID in the error message. The return value of that read was previously ignored, so a failed MDIO/SMI read left `regValue` undefined and could produce a misleading ID in the kernel log.

## Why this solution is correct

* `rtl8373_getAsicReg()` returns an `rtk_api_ret_t`, and the surrounding RTK code treats any value other than `RT_ERR_OK` as a failed read.
* On a failed fallback read, returning the original SDK error preserves the actual communication failure for the caller instead of reporting an unsupported chip with an invented ID.
* On a successful read, the existing unsupported-device diagnostic and `RT_ERR_CHIP_NOT_SUPPORTED` return value are unchanged.
* The patch does not alter chip detection, retry count, supported chip IDs, or the normal probe path.

## Validation

* `git diff --check`
* `scripts/checkpatch.pl --no-tree --terse`
* Cross-checked the return type and error convention in the bundled RTK `switch_probe()` and DAL implementations.
* No hardware or full OpenWrt build was available on this macOS host.

## Requested review

Please verify the preferred error policy when the diagnostic device-ID read itself fails: returning the SDK communication error should make the root cause visible to the MDIO/DSA probe caller. A fault-injection or disconnected-SMI test should confirm that the log reports the read error and never prints an uninitialized device ID.

## Confidence

Approximately 96%. This is a localized error-path fix with no change to successful detection or hardware programming.