### PR TITLE
rtl837x: roll back VLAN shadow state on write errors

### DIFF
--- a/package/kernel/rtl837x/src/rtl837x_dsa_ops.c
+++ b/package/kernel/rtl837x/src/rtl837x_dsa_ops.c
@@ -201,10 +201,13 @@ static int rtl837x_tag_8021q_vlan_add(struct dsa_switch *ds, int port, u16 vid,
 	struct rtk_gsw *gsw = ds->priv;
 	bool untagged = flags & BRIDGE_VLAN_INFO_UNTAGGED;
 	bool pvid = flags & BRIDGE_VLAN_INFO_PVID;
+	typeof(gsw->vlan_table[0]) old_vlan;
 	int ret;
 
 	if (!rtl837x_valid_port(gsw, port) || !vid || vid > RTK_VID_MAX)
 		return -EINVAL;
+
+	old_vlan = gsw->vlan_table[vid];
 
 	gsw->vlan_table[vid].valid = 1;
 	gsw->vlan_table[vid].vid = vid;
@@ -216,8 +219,10 @@ static int rtl837x_tag_8021q_vlan_add(struct dsa_switch *ds, int port, u16 vid,
 		gsw->vlan_table[vid].untag &= ~BIT(port);
 
 	ret = rtl837x_write_vlan(gsw, vid);
-	if (ret)
+	if (ret) {
+		gsw->vlan_table[vid] = old_vlan;
 		return ret;
+	}
 
 	if (pvid) {
 		gsw->tag8021q_pvid[port] = vid;
@@ -231,6 +236,7 @@ static int rtl837x_tag_8021q_vlan_add(struct dsa_switch *ds, int port, u16 vid,
 static int rtl837x_tag_8021q_vlan_del(struct dsa_switch *ds, int port, u16 vid)
 {
 	struct rtk_gsw *gsw = ds->priv;
+	typeof(gsw->vlan_table[0]) old_vlan;
 	int ret;
 
 	if (!rtl837x_valid_port(gsw, port) || !vid || vid > RTK_VID_MAX)
@@ -239,6 +245,8 @@ static int rtl837x_tag_8021q_vlan_del(struct dsa_switch *ds, int port, u16 vid)
 	if (!gsw->vlan_table[vid].valid)
 		return 0;
 
+	old_vlan = gsw->vlan_table[vid];
+
 	gsw->vlan_table[vid].mbr &= ~BIT(port);
 	gsw->vlan_table[vid].untag &= ~BIT(port);
 
@@ -246,8 +254,10 @@ static int rtl837x_tag_8021q_vlan_del(struct dsa_switch *ds, int port, u16 vid)
 		gsw->vlan_table[vid].valid = 0;
 
 	ret = rtl837x_write_vlan(gsw, vid);
-	if (ret)
+	if (ret) {
+		gsw->vlan_table[vid] = old_vlan;
 		return ret;
+	}
 
 	if (gsw->tag8021q_pvid_valid[port] && gsw->tag8021q_pvid[port] == vid) {
 		gsw->tag8021q_pvid_valid[port] = false;
@@ -715,6 +725,7 @@ static int rtl837x_port_vlan_add(struct dsa_switch *ds, int port,
 	bool untagged = vlan->flags & BRIDGE_VLAN_INFO_UNTAGGED;
 	bool pvid = vlan->flags & BRIDGE_VLAN_INFO_PVID;
 	u16 vid = vlan->vid;
+	typeof(gsw->vlan_table[0]) old_vlan;
 	int ret;
 
 	if (!rtl837x_valid_port(gsw, port))
@@ -727,6 +738,8 @@ static int rtl837x_port_vlan_add(struct dsa_switch *ds, int port,
 		NL_SET_ERR_MSG_MOD(extack, "VLAN ID out of range");
 		return -EINVAL;
 	}
+
+	old_vlan = gsw->vlan_table[vid];
 
 	gsw->vlan_table[vid].valid = 1;
 	gsw->vlan_table[vid].vid = vid;
@@ -743,6 +756,7 @@ static int rtl837x_port_vlan_add(struct dsa_switch *ds, int port,
 
 	ret = rtl837x_write_vlan(gsw, vid);
 	if (ret) {
+		gsw->vlan_table[vid] = old_vlan;
 		NL_SET_ERR_MSG_MOD(extack, "failed to program VLAN");
 		return ret;
 	}
@@ -761,6 +775,7 @@ static int rtl837x_port_vlan_del(struct dsa_switch *ds, int port,
 {
 	struct rtk_gsw *gsw = ds->priv;
 	u16 vid = vlan->vid;
+	typeof(gsw->vlan_table[0]) old_vlan;
 	int ret;
 
 	if (!rtl837x_valid_port(gsw, port))
@@ -768,6 +783,8 @@ static int rtl837x_port_vlan_del(struct dsa_switch *ds, int port,
 
 	if (!vid || vid > RTK_VID_MAX || !gsw->vlan_table[vid].valid)
 		return 0;
+
+	old_vlan = gsw->vlan_table[vid];
 
 	gsw->vlan_table[vid].mbr &= ~BIT(port);
 	gsw->vlan_table[vid].untag &= ~BIT(port);
@@ -781,8 +798,10 @@ static int rtl837x_port_vlan_del(struct dsa_switch *ds, int port,
 		gsw->vlan_table[vid].valid = 0;
 
 	ret = rtl837x_write_vlan(gsw, vid);
-	if (ret)
+	if (ret) {
+		gsw->vlan_table[vid] = old_vlan;
 		return ret;
+	}
 
 	if (port != gsw->cpu_port && gsw->bridge_pvid_valid[port] &&
 	    gsw->bridge_pvid[port] == vid) {


### PR DESCRIPTION
## Summary

Restore the RTL837x VLAN shadow entry when programming the corresponding hardware VLAN entry fails.

The DSA VLAN callbacks update `gsw->vlan_table[vid]` before calling `rtl837x_write_vlan()`. If `rtk_vlan_set()` fails, the callback returns an error but the shadow entry keeps the uncommitted membership, tagging, and validity changes. A later retry or another VLAN operation can then build its hardware request from state that was never accepted by the switch.

This applies consistently to both the `tag_8021q` VLAN callbacks and the regular DSA `port_vlan` callbacks.

## Why this solution is correct

* DSA reports the callback error to switchdev, so a failed VLAN operation must not be represented as committed in the driver shadow state.
* The old entry is copied only after the port and VLAN ID have passed validation.
* On a failed `rtl837x_write_vlan()`, the complete anonymous VLAN entry is restored, including `valid`, `vid`, `mbr`, and `untag`.
* On success, the existing state transition and hardware programming are unchanged.
* PVID updates remain after a successful VLAN write and are intentionally outside this change; this patch addresses the direct VLAN-table write transaction only.

## Validation

* `git diff --check`
* `scripts/checkpatch.pl --no-tree --terse`
* Reviewed all four VLAN add/delete callbacks for matching rollback behavior.
* Cross-checked the DSA/switchdev error-return contract.
* No Flint 3 hardware or full OpenWrt build was available on this macOS host.

## Requested review

Please verify with a forced `rtk_vlan_set()`/SMI write failure that:

1. The callback returns an error.
2. A subsequent retry starts from the pre-failure shadow membership and tagging state.
3. No successful VLAN operation changes behavior.
4. The same behavior is present for both `tag_8021q` and regular DSA VLAN callbacks.

The bridge VLAN functional behavior is not intentionally changed; this is an error-path consistency fix.

## Confidence

Approximately 94%. The issue is a direct state-ordering mismatch visible in the callback code, and the rollback is limited to the exact entry whose hardware write failed.