### PR TITLE
rtl837x: use sleepable reset GPIO accessors

### DIFF
--- a/package/kernel/rtl837x/src/rtl837x_mdio.c
+++ b/package/kernel/rtl837x/src/rtl837x_mdio.c
@@ -299,13 +299,13 @@ END_DETECT_CHIP:
 
 static int rtl837x_hw_reset(struct rtk_gsw *gsw)
 {
-	if (!IS_ERR(gsw->reset_pin)) {
+	if (!IS_ERR_OR_NULL(gsw->reset_pin)) {
 		dev_info(gsw->dev, "START HW RESET");
-		gpiod_set_value(gsw->reset_pin, 1);
+		gpiod_set_value_cansleep(gsw->reset_pin, 1);
 		mdelay(100);
-		gpiod_set_value(gsw->reset_pin, 0);
+		gpiod_set_value_cansleep(gsw->reset_pin, 0);
 		mdelay(100);
-		gpiod_set_value(gsw->reset_pin, 1);
+		gpiod_set_value_cansleep(gsw->reset_pin, 1);
 		mdelay(100);
 		dev_info(gsw->dev, "FINISH HW RESET");
 	}


### PR DESCRIPTION
## Summary

Use the sleepable GPIO accessor and handle the optional reset descriptor correctly in `rtl837x_hw_reset()`.

`devm_gpiod_get_optional()` returns `NULL) when no reset GPIO is described. The existing `!IS_ERR()` check treats that value as usable and passes it to the GPIO setter. In addition, the descriptor may belong to a GPIO controller that requires sleeping access.

## Why this solution is correct

* `IS_ERR_OR_NULL()` skips the reset sequence when the optional GPIO is absent and is also safe if probe error handling has not yet rejected an error pointer.
* `gpiod_set_value_cansleep()` is the kernel accessor for GPIO descriptors that may require a sleeping bus transaction, such as an I2C or SPI GPIO expander.
* The cansleep accessor preserves the same logical active-high/active-low semantics as `gpiod_set_value()`.
* Probe and switch-reset paths already run in sleepable process context, so the accessor is valid there.
* The three reset levels and delays are unchanged.
* This complements PR #17, which propagates an error returned while acquiring the reset GPIO; it does not replace that probe-time error handling.

## Validation

* `git diff --check`
* `scripts/checkpatch.pl --no-tree --terse`
* Cross-checked the optional GPIO return contract and the Linux GPIO consumer API.
* No Flint 3 hardware or full OpenWrt build was available on this macOS host.

## Requested review

Please verify both supported configurations:

1. A device tree with no `reset-gpios`: probe should skip the reset sequence without calling the GPIO API with `NULL`.
2. A sleep-capable GPIO controller: probe and the switch reset operation should complete without a sleeping-context warning.

For a normal SoC GPIO, the reset waveform should remain unchanged.

## Confidence

Approximately 97%. The change follows the documented Linux GPIO consumer contract and preserves the existing reset sequence while correcting the optional-descriptor and sleepable-controller cases.