### PR TITLE
rtl837x: cancel status work during shutdown

### DIFF
--- a/package/kernel/rtl837x/src/rtl837x_mdio.c
+++ b/package/kernel/rtl837x/src/rtl837x_mdio.c
@@ -912,6 +912,7 @@ static void rtl837x_mdio_shutdown(struct mdio_device *mdiodev)
 	if (!gsw)
 		return;
 
+	cancel_delayed_work_sync(&gsw->status_check_work);
 	rtl837x_dsa_shutdown(gsw);
 	if (gsw->ethernet_master) {
 		dev_put(gsw->ethernet_master);


### PR DESCRIPTION
## Summary

Cancel the asynchronous CPU-port status worker from the MDIO driver shutdown callback.

The worker periodically reads CPU-port status and may close/reopen the Ethernet master and change the switch SerDes mode. The normal remove path already calls `cancel_delayed_work_sync()), but `rtl837x_mdio_shutdown()` did not. During reboot or poweroff, the worker could therefore race with DSA and MDIO shutdown.

## Why this solution is correct

* `status_check_work` is initialized before probe returns successfully and is the only delayed work owned by this driver.
* `cancel_delayed_work_sync()` cancels a pending timer and waits for an already-running callback to finish.
* It is called before `rtl837x_dsa_shutdown()` and before releasing the Ethernet master reference, so the worker cannot start a new hardware operation after those teardown steps.
* The existing remove path already establishes the same ordering, so this aligns shutdown with the established cleanup path.
* No normal probe, link-monitor, or unbind behavior is changed.

## Validation

* `git diff --check`
* `scripts/checkpatch.pl --no-tree --terse`
* Cross-checked the driver-model shutdown contract and workqueue cancellation API.
* No Flint 3 hardware or full OpenWrt build was available on this macOS host.

## Requested review

Please verify reboot and poweroff with the status worker enabled. The expected result is that no CPU-port SerDes reset or Ethernet master reopen occurs after shutdown begins. Also confirm that normal driver remove still cancels the worker exactly once.

## Confidence

Approximately 95%. The worker is explicitly scheduled by this driver, the remove path already cancels it, and the shutdown callback otherwise tears down the same resources that the worker uses.