### PR TITLE
rtl837x: roll back PVID shadow state on write errors

### DIFF
--- a/package/kernel/rtl837x/src/rtl837x_dsa_ops.c
+++ b/package/kernel/rtl837x/src/rtl837x_dsa_ops.c
@@ -220,9 +220,17 @@ static int rtl837x_tag_8021q_vlan_add(struct dsa_switch *ds, int port, u16 vid,
 		return ret;
 
 	if (pvid) {
+		u16 old_pvid = gsw->tag8021q_pvid[port];
+		bool old_pvid_valid = gsw->tag8021q_pvid_valid[port];
+
 		gsw->tag8021q_pvid[port] = vid;
 		gsw->tag8021q_pvid_valid[port] = true;
-		return rtl837x_commit_pvid(gsw, port);
+		ret = rtl837x_commit_pvid(gsw, port);
+		if (ret) {
+			gsw->tag8021q_pvid[port] = old_pvid;
+			gsw->tag8021q_pvid_valid[port] = old_pvid_valid;
+		}
+		return ret;
 	}
 
 	return 0;
@@ -250,8 +258,16 @@ static int rtl837x_tag_8021q_vlan_del(struct dsa_switch *ds, int port, u16 vid)
 		return ret;
 
 	if (gsw->tag8021q_pvid_valid[port] && gsw->tag8021q_pvid[port] == vid) {
+		u16 old_pvid = gsw->tag8021q_pvid[port];
+		bool old_pvid_valid = gsw->tag8021q_pvid_valid[port];
+
 		gsw->tag8021q_pvid_valid[port] = false;
-		return rtl837x_commit_pvid(gsw, port);
+		ret = rtl837x_commit_pvid(gsw, port);
+		if (ret) {
+			gsw->tag8021q_pvid[port] = old_pvid;
+			gsw->tag8021q_pvid_valid[port] = old_pvid_valid;
+		}
+		return ret;
 	}
 
 	return 0;
@@ -748,9 +764,17 @@ static int rtl837x_port_vlan_add(struct dsa_switch *ds, int port,
 	}
 
 	if (pvid && port != gsw->cpu_port) {
+		u16 old_pvid = gsw->bridge_pvid[port];
+		bool old_pvid_valid = gsw->bridge_pvid_valid[port];
+
 		gsw->bridge_pvid[port] = vid;
 		gsw->bridge_pvid_valid[port] = true;
-		return rtl837x_commit_pvid(gsw, port);
+		ret = rtl837x_commit_pvid(gsw, port);
+		if (ret) {
+			gsw->bridge_pvid[port] = old_pvid;
+			gsw->bridge_pvid_valid[port] = old_pvid_valid;
+		}
+		return ret;
 	}
 
 	return 0;
@@ -786,8 +810,16 @@ static int rtl837x_port_vlan_del(struct dsa_switch *ds, int port,
 
 	if (port != gsw->cpu_port && gsw->bridge_pvid_valid[port] &&
 	    gsw->bridge_pvid[port] == vid) {
+		u16 old_pvid = gsw->bridge_pvid[port];
+		bool old_pvid_valid = gsw->bridge_pvid_valid[port];
+
 		gsw->bridge_pvid_valid[port] = false;
-		return rtl837x_commit_pvid(gsw, port);
+		ret = rtl837x_commit_pvid(gsw, port);
+		if (ret) {
+			gsw->bridge_pvid[port] = old_pvid;
+			gsw->bridge_pvid_valid[port] = old_pvid_valid;
+		}
+		return ret;
 	}
 
 	return 0;


### PR DESCRIPTION
## Summary

Roll back the driver PVID shadow state when programming the hardware PVID fails.

The `tag_8021q_vlan_add/del` and regular `port_vlan_add/del` callbacks update their `tag8021q_pvid` or `bridge_pvid` fields before calling `rtl837x_commit_pvid()`. If `rtk_vlan_portPvid_set()` fails, the callback returns an error but the shadow state still describes the rejected PVID operation. Later filtering or VLAN operations can then use a PVID that was never committed to the switch.

## Why this solution is correct

* The DSA callback returns the hardware error, so the associated software shadow must remain at the pre-operation value.
* Each path saves both the previous VID and its validity flag before changing the shadow state.
* On a failed PVID write, the saved pair is restored. On success, the existing state and `port_pvid` update behavior are unchanged.
* The fix covers both internal `tag_8021q` VLAN management and regular bridge VLAN management.
* This is complementary to PR #34: #34 rolls back the VLAN membership entry when the VLAN-table write fails, while this patch handles the subsequent PVID write transaction.

## Validation

* `git diff --check`
* `scripts/checkpatch.pl --no-tree --terse`
* Reviewed add and delete paths for both PVID shadow arrays.
* Cross-checked the existing `rtl837x_commit_pvid()` ordering: `port_pvid` is updated only after a successful hardware write.
* No Flint 3 hardware or full OpenWrt build was available on this macOS host.

## Requested review

Please fault-inject a failure from `rtk_vlan_portPvid_set()` during:

1. A tag_8021q PVID add.
2. A tag_8021q PVID delete.
3. A bridge PVID add.
4. A bridge PVID delete.

In each case, the DSA callback should return an error and a subsequent retry should start from the pre-failure shadow state. Please also confirm that successful PVID changes remain unchanged.

## Confidence

Approximately 94%. The issue is a direct ordering mismatch between the returned hardware error and the persistent shadow update; the rollback is limited to the exact state changed by the failed operation.