### PR TITLE
rtl837x: avoid pinning status work to current CPU

### DIFF
--- a/package/kernel/rtl837x/src/rtl837x_mdio.c
+++ b/package/kernel/rtl837x/src/rtl837x_mdio.c
@@ -567,11 +567,8 @@ static void rtl837x_status_check_work_func(struct work_struct *work)
 		mdelay(2000);
 	}
 
-	queue_delayed_work_on(smp_processor_id(), 
-						system_wq, 
-						&gsw->status_check_work, 
-						msecs_to_jiffies(gsw->default_work_delay_ms)
-					);
+	queue_delayed_work(system_wq, &gsw->status_check_work,
+				   msecs_to_jiffies(gsw->default_work_delay_ms));
 }
 
 /* unused */
@@ -674,11 +671,8 @@ static int rtl837x_status_check_work_init(struct rtk_gsw *gsw)
 {
 	gsw->default_work_delay_ms = 1000;
 	INIT_DELAYED_WORK(&gsw->status_check_work, rtl837x_status_check_work_func);
-	queue_delayed_work_on(smp_processor_id(), 
-						system_wq, 
-						&gsw->status_check_work, 
-						msecs_to_jiffies(gsw->default_work_delay_ms)
-					);
+	queue_delayed_work(system_wq, &gsw->status_check_work,
+				   msecs_to_jiffies(gsw->default_work_delay_ms));
 	return 0;
 }
 


### PR DESCRIPTION
## Summary

The periodic CPU-port status worker queued its delayed work with `queue_delayed_work_on(smp_processor_id(), system_wq, ...)` in both the initial setup and the self-requeue path.

This changes both call sites to `queue_delayed_work(system_wq, ...)`.

## Why this is the correct API

`rtl837x_status_check_work_init()` runs from probe context and `rtl837x_status_check_work_func()` runs from a preemptible workqueue context. Neither caller establishes a stable CPU context before calling `smp_processor_id()`. Linux documents that `smp_processor_id()` requires IRQs or preemption to be disabled, or a CPU-affine task, and may warn with `CONFIG_DEBUG_PREEMPT`:

- https://github.com/torvalds/linux/blob/master/include/linux/smp.h#L243-L262

The generic delayed-work helper uses `WORK_CPU_UNBOUND`, which means the workqueue may prefer the local CPU without requiring the caller to read an unstable CPU number:

- https://github.com/torvalds/linux/blob/master/include/linux/workqueue.h#L658-L670

The worker has no per-CPU state: it operates on the shared `struct rtk_gsw` instance and the switch API. Removing the explicit CPU argument therefore avoids an invalid CPU-ID assumption and an unnecessary hard pin while retaining the existing system workqueue and delay.

The legacy `rtl837x_swconfig.c` source is not part of the active `rtl837x_dsa` object list, so this PR is limited to the compiled DSA path.

## Validation

- `git diff --check`
- `scripts/checkpatch.pl --no-tree --terse`
- Full target build and hardware testing were not available in this environment.

## Confidence and requested review

Static confidence: 92%. Please confirm that status polling has no intentional CPU-affinity requirement. On hardware or with `CONFIG_DEBUG_PREEMPT`, please verify that the worker continues to poll CPU-port link state and perform the existing SerDes recovery without warnings or behavior changes.