### PR TITLE
rtl837x: harden SFP SerDes mode transitions

### DIFF
--- a/package/kernel/rtl837x/src/rtl837x_mdio.c
+++ b/package/kernel/rtl837x/src/rtl837x_mdio.c
@@ -592,6 +592,8 @@ static int rtl837x_sfp_module_insert(void *upstream, const struct sfp_eeprom_id 
 {
 	struct rtk_gsw *gsw = upstream;
 	phy_interface_t iface;
+	rtk_sds_mode_t old_mode = gsw->sds1mode;
+	rtk_api_ret_t ret;
 
 #if LINUX_VERSION_CODE >= KERNEL_VERSION(6,18,0)
 	const struct sfp_module_caps *caps;
@@ -625,17 +627,29 @@ static int rtl837x_sfp_module_insert(void *upstream, const struct sfp_eeprom_id 
 		return -EINVAL;
 	}
 
-	rtk_sdsMode_set(1, gsw->sds1mode);
+	ret = rtk_sdsMode_set(1, gsw->sds1mode);
+	if (ret) {
+		gsw->sds1mode = old_mode;
+		dev_err(gsw->dev, "failed to set SFP SerDes mode: %d\n", ret);
+		return -EIO;
+	}
+
 	return 0;
 }
 
 static void rtl837x_sfp_module_remove(void *upstream)
 {
 	struct rtk_gsw *gsw = upstream;
+	rtk_sds_mode_t old_mode = gsw->sds1mode;
+	rtk_api_ret_t ret;
 	dev_info(gsw->dev, "SFP module remove\n");
 
 	USE_SERDESMODE(1, SERDES_OFF);
-	rtk_sdsMode_set(1, gsw->sds1mode);
+	ret = rtk_sdsMode_set(1, gsw->sds1mode);
+	if (ret) {
+		gsw->sds1mode = old_mode;
+		dev_err(gsw->dev, "failed to disable SFP SerDes: %d\n", ret);
+	}
 }
 
 static const struct sfp_upstream_ops sfp_ops = {


### PR DESCRIPTION
## Summary

`USE_SERDESMODE(1, ...)` updates `gsw->sds1mode` before the driver programs the hardware with `rtk_sdsMode_set()`.

If the hardware operation fails, the callback previously left the software shadow at the requested new mode even though the switch may still be in the previous mode. This patch saves the previous mode and restores it whenever SFP SerDes programming fails during insertion or removal.

The insertion callback also reports the failure to the SFP core with `-EIO`, and the removal callback logs the failure because its upstream API is void. Those error-reporting parts are the same boundary handled by PRs #20 and #24; this PR adds the missing shadow-state rollback and can be folded into or applied after those changes.

## Why this is correct

The `USE_SERDESMODE` macro is the only operation that changes the cached `sds1mode` in these callbacks. The subsequent `rtk_sdsMode_set()` is the operation that attempts to make hardware match that cached value. Therefore, if that operation returns a Realtek error, retaining the new cached value is incorrect: future recovery or reinitialization would use a mode that was not confirmed by hardware.

The patch does not issue a speculative second hardware write after a failed transaction. It only restores the software shadow, preserving the existing failure behavior while preventing later code from relying on an unconfirmed mode. Successful insertion, removal, interface selection, and force-mode behavior are unchanged.

## Validation

- `git diff --check`
- `scripts/checkpatch.pl --no-tree --terse`
- Verified `rtk_sdsMode_set()` returns `rtk_api_ret_t` and that `USE_SERDESMODE` updates `sds1mode` before the call.
- Full target build and Flint 3 hardware testing were not available in this environment.

## Confidence and review request

Static confidence: 95%. Please review this together with #20 and #24 and either merge the rollback independently or fold it into the existing SFP error-reporting changes.

Please test:

1. normal supported SFP insertion and removal;
2. a forced SMI/SerDes programming failure during insertion, confirming the callback fails and the previous shadow mode remains;
3. a programming failure during removal, confirming the old shadow mode remains while SFP teardown still completes;
4. a subsequent recovery or reinitialization after each failure.