### PR TITLE
rtl837x: keep VLAN shadow state consistent on errors

### DIFF
--- a/package/kernel/rtl837x/src/rtl837x_dsa_ops.c
+++ b/package/kernel/rtl837x/src/rtl837x_dsa_ops.c
@@ -201,10 +201,13 @@ static int rtl837x_tag_8021q_vlan_add(struct dsa_switch *ds, int port, u16 vid,
 	struct rtk_gsw *gsw = ds->priv;
 	bool untagged = flags & BRIDGE_VLAN_INFO_UNTAGGED;
 	bool pvid = flags & BRIDGE_VLAN_INFO_PVID;
+	typeof(gsw->vlan_table[0]) old_vlan;
 	int ret;
 
 	if (!rtl837x_valid_port(gsw, port) || !vid || vid > RTK_VID_MAX)
 		return -EINVAL;
+
+	old_vlan = gsw->vlan_table[vid];
 
 	gsw->vlan_table[vid].valid = 1;
 	gsw->vlan_table[vid].vid = vid;
@@ -216,13 +219,23 @@ static int rtl837x_tag_8021q_vlan_add(struct dsa_switch *ds, int port, u16 vid,
 		gsw->vlan_table[vid].untag &= ~BIT(port);
 
 	ret = rtl837x_write_vlan(gsw, vid);
-	if (ret)
+	if (ret) {
+		gsw->vlan_table[vid] = old_vlan;
 		return ret;
+	}
 
 	if (pvid) {
+		u16 old_pvid = gsw->tag8021q_pvid[port];
+		bool old_pvid_valid = gsw->tag8021q_pvid_valid[port];
+
 		gsw->tag8021q_pvid[port] = vid;
 		gsw->tag8021q_pvid_valid[port] = true;
-		return rtl837x_commit_pvid(gsw, port);
+		ret = rtl837x_commit_pvid(gsw, port);
+		if (ret) {
+			gsw->tag8021q_pvid[port] = old_pvid;
+			gsw->tag8021q_pvid_valid[port] = old_pvid_valid;
+		}
+		return ret;
 	}
 
 	return 0;
@@ -231,6 +244,7 @@ static int rtl837x_tag_8021q_vlan_add(struct dsa_switch *ds, int port, u16 vid,
 static int rtl837x_tag_8021q_vlan_del(struct dsa_switch *ds, int port, u16 vid)
 {
 	struct rtk_gsw *gsw = ds->priv;
+	typeof(gsw->vlan_table[0]) old_vlan;
 	int ret;
 
 	if (!rtl837x_valid_port(gsw, port) || !vid || vid > RTK_VID_MAX)
@@ -239,6 +253,8 @@ static int rtl837x_tag_8021q_vlan_del(struct dsa_switch *ds, int port, u16 vid)
 	if (!gsw->vlan_table[vid].valid)
 		return 0;
 
+	old_vlan = gsw->vlan_table[vid];
+
 	gsw->vlan_table[vid].mbr &= ~BIT(port);
 	gsw->vlan_table[vid].untag &= ~BIT(port);
 
@@ -246,12 +262,22 @@ static int rtl837x_tag_8021q_vlan_del(struct dsa_switch *ds, int port, u16 vid)
 		gsw->vlan_table[vid].valid = 0;
 
 	ret = rtl837x_write_vlan(gsw, vid);
-	if (ret)
+	if (ret) {
+		gsw->vlan_table[vid] = old_vlan;
 		return ret;
+	}
 
 	if (gsw->tag8021q_pvid_valid[port] && gsw->tag8021q_pvid[port] == vid) {
+		u16 old_pvid = gsw->tag8021q_pvid[port];
+		bool old_pvid_valid = gsw->tag8021q_pvid_valid[port];
+
 		gsw->tag8021q_pvid_valid[port] = false;
-		return rtl837x_commit_pvid(gsw, port);
+		ret = rtl837x_commit_pvid(gsw, port);
+		if (ret) {
+			gsw->tag8021q_pvid[port] = old_pvid;
+			gsw->tag8021q_pvid_valid[port] = old_pvid_valid;
+		}
+		return ret;
 	}
 
 	return 0;
@@ -715,6 +741,7 @@ static int rtl837x_port_vlan_add(struct dsa_switch *ds, int port,
 	bool untagged = vlan->flags & BRIDGE_VLAN_INFO_UNTAGGED;
 	bool pvid = vlan->flags & BRIDGE_VLAN_INFO_PVID;
 	u16 vid = vlan->vid;
+	typeof(gsw->vlan_table[0]) old_vlan;
 	int ret;
 
 	if (!rtl837x_valid_port(gsw, port))
@@ -727,6 +754,8 @@ static int rtl837x_port_vlan_add(struct dsa_switch *ds, int port,
 		NL_SET_ERR_MSG_MOD(extack, "VLAN ID out of range");
 		return -EINVAL;
 	}
+
+	old_vlan = gsw->vlan_table[vid];
 
 	gsw->vlan_table[vid].valid = 1;
 	gsw->vlan_table[vid].vid = vid;
@@ -743,14 +772,23 @@ static int rtl837x_port_vlan_add(struct dsa_switch *ds, int port,
 
 	ret = rtl837x_write_vlan(gsw, vid);
 	if (ret) {
+		gsw->vlan_table[vid] = old_vlan;
 		NL_SET_ERR_MSG_MOD(extack, "failed to program VLAN");
 		return ret;
 	}
 
 	if (pvid && port != gsw->cpu_port) {
+		u16 old_pvid = gsw->bridge_pvid[port];
+		bool old_pvid_valid = gsw->bridge_pvid_valid[port];
+
 		gsw->bridge_pvid[port] = vid;
 		gsw->bridge_pvid_valid[port] = true;
-		return rtl837x_commit_pvid(gsw, port);
+		ret = rtl837x_commit_pvid(gsw, port);
+		if (ret) {
+			gsw->bridge_pvid[port] = old_pvid;
+			gsw->bridge_pvid_valid[port] = old_pvid_valid;
+		}
+		return ret;
 	}
 
 	return 0;
@@ -761,6 +799,7 @@ static int rtl837x_port_vlan_del(struct dsa_switch *ds, int port,
 {
 	struct rtk_gsw *gsw = ds->priv;
 	u16 vid = vlan->vid;
+	typeof(gsw->vlan_table[0]) old_vlan;
 	int ret;
 
 	if (!rtl837x_valid_port(gsw, port))
@@ -768,6 +807,8 @@ static int rtl837x_port_vlan_del(struct dsa_switch *ds, int port,
 
 	if (!vid || vid > RTK_VID_MAX || !gsw->vlan_table[vid].valid)
 		return 0;
+
+	old_vlan = gsw->vlan_table[vid];
 
 	gsw->vlan_table[vid].mbr &= ~BIT(port);
 	gsw->vlan_table[vid].untag &= ~BIT(port);
@@ -781,13 +822,23 @@ static int rtl837x_port_vlan_del(struct dsa_switch *ds, int port,
 		gsw->vlan_table[vid].valid = 0;
 
 	ret = rtl837x_write_vlan(gsw, vid);
-	if (ret)
+	if (ret) {
+		gsw->vlan_table[vid] = old_vlan;
 		return ret;
+	}
 
 	if (port != gsw->cpu_port && gsw->bridge_pvid_valid[port] &&
 	    gsw->bridge_pvid[port] == vid) {
+		u16 old_pvid = gsw->bridge_pvid[port];
+		bool old_pvid_valid = gsw->bridge_pvid_valid[port];
+
 		gsw->bridge_pvid_valid[port] = false;
-		return rtl837x_commit_pvid(gsw, port);
+		ret = rtl837x_commit_pvid(gsw, port);
+		if (ret) {
+			gsw->bridge_pvid[port] = old_pvid;
+			gsw->bridge_pvid_valid[port] = old_pvid_valid;
+		}
+		return ret;
 	}
 
 	return 0;


### PR DESCRIPTION
## Summary

Consolidate PRs #34 and #37 into one transactional shadow-state fix.

The DSA VLAN callbacks now restore:

- VLAN membership/tagging shadow state when the VLAN-table write fails;
- tag_8021q and bridge PVID shadow state when the PVID write fails.

Both regular bridge VLAN and internal tag_8021q paths are covered for add and delete operations.

## Why this solution is believed to be correct

The driver updates its software shadow before programming the corresponding hardware state. If the hardware operation returns an error, retaining the new shadow would make later operations trust a change that was not accepted by the switch. The combined change restores exactly the fields modified by the failed operation and leaves successful operations unchanged.

## Review organization

During the audit of PRs #10-#40, these two changes were found to implement the same invariant across the same four VLAN callback pairs. They were consolidated into one review unit for easier verification and confirmation. This does not add a new hardware feature or change the successful programming path.

## Validation

- git diff --check
- scripts/checkpatch.pl --no-tree --terse
- No full target build or Flint 3 hardware test was available in this environment.

## Review request

Please fault-inject VLAN-table and PVID write failures in both regular DSA VLAN and tag_8021q paths, for add and delete. A failed operation should return an error and the next retry should start from the pre-operation shadow state.

## Confidence

Approximately 95% for the state-consistency logic. Runtime confirmation is requested for partial hardware-failure behavior and retries.