### PR TITLE
rtl837x: handle reset GPIO lifecycle correctly

### DIFF
--- a/package/kernel/rtl837x/src/rtl837x_mdio.c
+++ b/package/kernel/rtl837x/src/rtl837x_mdio.c
@@ -329,13 +329,13 @@ END_DETECT_CHIP:
 
 static int rtl837x_hw_reset(struct rtk_gsw *gsw)
 {
-	if (!IS_ERR(gsw->reset_pin)) {
+	if (!IS_ERR_OR_NULL(gsw->reset_pin)) {
 		dev_info(gsw->dev, "START HW RESET");
-		gpiod_set_value(gsw->reset_pin, 1);
+		gpiod_set_value_cansleep(gsw->reset_pin, 1);
 		mdelay(100);
-		gpiod_set_value(gsw->reset_pin, 0);
+		gpiod_set_value_cansleep(gsw->reset_pin, 0);
 		mdelay(100);
-		gpiod_set_value(gsw->reset_pin, 1);
+		gpiod_set_value_cansleep(gsw->reset_pin, 1);
 		mdelay(100);
 		dev_info(gsw->dev, "FINISH HW RESET");
 	}
@@ -897,7 +897,18 @@ static int rtl837x_dsa_probe(struct mdio_device *mdiodev)
 
 	gsw->reset_pin = devm_gpiod_get_optional(dev, "reset", GPIOD_OUT_LOW);
 	if (IS_ERR(gsw->reset_pin)) {
-		dev_warn(dev, "failed to get RESET GPIO!!!\n");
+		ret = PTR_ERR(gsw->reset_pin);
+		if (ret == -EPROBE_DEFER) {
+			dev_err_probe(dev, ret, "failed to get reset GPIO\n");
+			if (master)
+				dev_put(master);
+			return ret;
+		}
+
+		dev_warn(dev,
+			 "failed to get reset GPIO: %d; "
+			 "continuing without reset GPIO\n", ret);
+		gsw->reset_pin = NULL;
 	}
 
 	if (!of_property_read_string(np, "rtl837x,sds0mode", &sdsmode_name) &&


### PR DESCRIPTION
## Summary

Consolidate the reset-GPIO lifecycle fix while keeping the GPIO optional.

- use IS_ERR_OR_NULL before attempting a reset;
- use gpiod_set_value_cansleep for providers that may sleep;
- abort probe only for EPROBE_DEFER;
- warn and clear the descriptor for other optional-GPIO errors so the switch
  continues without reset control.

The reset levels, polarity handling, and delays are unchanged for a valid
descriptor.

## Why this is correct

The optional GPIO consumer API distinguishes an absent descriptor from an
ERR_PTR acquisition failure. A reset GPIO is auxiliary to the data path, so a
non-deferred acquisition problem must not unregister the DSA switch. A deferred
provider still requires the normal probe retry. The reset sequence runs in
probe context and therefore must use the sleepable accessor. This path is
before drvdata and global private state are installed, so no stale global
pointer is introduced by the defer path.

## Validation

- git diff --check: passed;
- checkpatch: no code errors; the only warning is commit-message line wrapping;
- full target build and Flint 3 hardware testing are not available in this
  checkout.

## Review request

Please verify device trees with no reset GPIO, a normal GPIO, a sleep-capable
GPIO provider, an acquisition failure, and EPROBE_DEFER. The normal reset
waveform should remain unchanged. Static confidence is approximately 98
percent; runtime confirmation is requested for the GPIO-provider variants.