### PR TITLE
rtl837x: propagate auxiliary probe failures

### DIFF
--- a/package/kernel/rtl837x/src/rtl837x_mdio.c
+++ b/package/kernel/rtl837x/src/rtl837x_mdio.c
@@ -665,6 +665,8 @@ static int rtl837x_sfp_probe(struct rtk_gsw *gsw)
 	gsw->sfp_bus = bus;
 
 	ret = sfp_bus_add_upstream(bus, gsw, &sfp_ops);
+	if (ret)
+		gsw->sfp_bus = NULL;
 	sfp_bus_put(bus);
 
 	return ret;
@@ -875,11 +877,29 @@ static int rtl837x_dsa_probe(struct mdio_device *mdiodev)
 	}
 
 #ifdef CONFIG_GPIOLIB
-	if (of_property_read_bool(np, "gpio-controller")) 
-		rtl837x_gpiochip_init(gsw);
+	if (of_property_read_bool(np, "gpio-controller")) {
+		ret = rtl837x_gpiochip_init(gsw);
+		if (ret) {
+			dev_err_probe(dev, ret,
+				      "failed to register GPIO controller\n");
+			rtl837x_dsa_unregister(gsw);
+			if (master)
+				dev_put(master);
+			devm_kfree(dev, gsw);
+			return ret;
+		}
+	}
 #endif /* CONFIG_GPIOLIB */
 
-	rtl837x_sfp_probe(gsw);
+	ret = rtl837x_sfp_probe(gsw);
+	if (ret) {
+		dev_err_probe(dev, ret, "failed to attach SFP bus\n");
+		rtl837x_dsa_unregister(gsw);
+		if (master)
+			dev_put(master);
+		devm_kfree(dev, gsw);
+		return ret;
+	}
 
 	rtl837x_debug_proc_init(gsw);
 	rtl837x_status_check_work_init(gsw);

--- a/package/kernel/rtl837x/src/rtl837x_mdio.c
+++ b/package/kernel/rtl837x/src/rtl837x_mdio.c
@@ -891,15 +891,8 @@ static int rtl837x_dsa_probe(struct mdio_device *mdiodev)
 	}
 #endif /* CONFIG_GPIOLIB */
 
-	ret = rtl837x_sfp_probe(gsw);
-	if (ret) {
-		dev_err_probe(dev, ret, "failed to attach SFP bus\n");
-		rtl837x_dsa_unregister(gsw);
-		if (master)
-			dev_put(master);
-		devm_kfree(dev, gsw);
-		return ret;
-	}
+	/* SFP is optional; keep a registration failure from tearing down DSA. */
+	rtl837x_sfp_probe(gsw);
 
 	rtl837x_debug_proc_init(gsw);
 	rtl837x_status_check_work_init(gsw);

--- a/package/kernel/rtl837x/src/rtl837x_mdio.c
+++ b/package/kernel/rtl837x/src/rtl837x_mdio.c
@@ -879,15 +879,10 @@ static int rtl837x_dsa_probe(struct mdio_device *mdiodev)
 #ifdef CONFIG_GPIOLIB
 	if (of_property_read_bool(np, "gpio-controller")) {
 		ret = rtl837x_gpiochip_init(gsw);
-		if (ret) {
+		if (ret)
 			dev_err_probe(dev, ret,
-				      "failed to register GPIO controller\n");
-			rtl837x_dsa_unregister(gsw);
-			if (master)
-				dev_put(master);
-			devm_kfree(dev, gsw);
-			return ret;
-		}
+				      "failed to register GPIO controller; "
+				      "continuing without GPIO\n");
 	}
 #endif /* CONFIG_GPIOLIB */
 


### PR DESCRIPTION
## Summary

Consolidate PRs #18 and #19 into one probe-lifecycle fix for optional auxiliary subsystems.

After the DSA switch has been registered:

- GPIO registration failures are reported with dev_err_probe() and treated as best effort, so an optional GPIO provider cannot take down the LAN data path;
- a failed SFP upstream registration clears gsw->sfp_bus, because the SFP core has already dropped its reference, and then continues without tearing down the DSA switch;
- successful and absent-optional-subsystem paths remain unchanged;
- the optional failure paths do not devm_kfree() gsw or unregister DSA while drvdata and the global private pointer still reference it.

## Why this solution is believed to be correct

GPIO and SFP are auxiliary features on this board, not prerequisites for the switch data path. A GPIO base collision, gpiolib resource failure, or optional SFP subsystem error should therefore be visible in the log without making the already registered switch unusable.

The SFP pointer must be cleared after sfp_bus_add_upstream() fails: the failed helper has already dropped its own reference, and retaining the pointer would make later removal call sfp_bus_del_upstream() on a bus that was never added. Keeping the main probe object alive until normal devres cleanup also avoids introducing a dangling drvdata or rtl_gbl_priv reference.

## Review organization

During the audit of PRs #10-#40, #18 and #19 were identified as the same post-registration lifecycle class: optional auxiliary setup must report its failure without unwinding the working DSA switch, while failed SFP ownership must be cleared. They were consolidated into one review unit for easier verification and confirmation. The scope is limited to those two paths.

## Validation

- git diff --check
- scripts/checkpatch.pl --no-tree --terse
- No full target build or Flint 3 hardware test was available in this environment.

## Review request

Please verify no-GPIO and no-SFP configurations, successful registration, deferred or invalid dependencies, forced GPIO registration failure, forced SFP upstream-registration failure, and remove/unbind cleanup. Confirm that the DSA switch, drvdata, global private pointer, and Ethernet-master reference are released exactly once.

## Confidence

Approximately 95% for the probe control flow and ownership reasoning. Runtime confirmation is requested for the optional-failure and deferred paths.