### PR TITLE
rtl837x: harden debugfs write handlers

### DIFF
--- a/package/kernel/rtl837x/src/rtl837x_dbg.c
+++ b/package/kernel/rtl837x/src/rtl837x_dbg.c
@@ -49,23 +49,28 @@ ssize_t _sdsreg_rw_write(struct file *filep, const char __user *ubuf,
 		return PTR_ERR(buf);
 	
 	if(buf[0] == 'w') {
-		if(sscanf(buf, "w %d %x %x %x", &sds_id, &page, &reg, &val) == -1)
+		if (sscanf(buf, "w %u %x %x %x", &sds_id, &page, &reg, &val) != 4) {
+			kfree(buf);
 			return -EFAULT;
-		else{
-			if (sds_id > 1)
+		} else {
+			if (sds_id > 1) {
+				kfree(buf);
 				return -EFAULT;
+			}
 			rtk_rtl8373_sds_reg_write(sds_id, page, reg, val);
 		}
 	} else if(buf[0] == 'r') {
-		if(sscanf(buf, "r %d %x %x", &sds_id, &page, &reg) == -1)
+		if (sscanf(buf, "r %u %x %x", &sds_id, &page, &reg) != 3) {
+			kfree(buf);
 			return -EFAULT;
-		else {
+		} else {
 			rtk_rtl8373_sds_reg_read(sds_id, page, reg, &val);
 			snprintf(_buf_rd_sdsreg, 64, "sds_id: %d, page: 0x%08x, reg: 0x%08x, val: 0x%08x\n", sds_id, page, reg, val);
 		}
 	} else {
 		snprintf(_buf_rd_sdsreg, 64, "echo \"w/r <sds_id> <page> <reg> [<val>]\" > sdsreg\n");
 	}
+	kfree(buf);
 	return count;
 }
 
@@ -80,23 +85,28 @@ ssize_t _phyreg_mmd_rw_write(struct file *filep, const char __user *ubuf,
 		return PTR_ERR(buf);
 	
 	if(buf[0] == 'w') {
-		if(sscanf(buf, "w %d %x %x %x", &port, &devad, &reg, &val) == -1)
+		if (sscanf(buf, "w %u %x %x %x", &port, &devad, &reg, &val) != 4) {
+			kfree(buf);
 			return -EFAULT;
-		else{
-			if (port > 9)
+		} else {
+			if (port > 9) {
+				kfree(buf);
 				return -EFAULT;
+			}
 			rtk_port_phyReg_set(1<<port, devad, reg, val);
 		}
 	} else if(buf[0] == 'r') {
-		if(sscanf(buf, "r %d %x %x", &port, &devad, &reg) == -1)
+		if (sscanf(buf, "r %u %x %x", &port, &devad, &reg) != 3) {
+			kfree(buf);
 			return -EFAULT;
-		else {
+		} else {
 			rtk_port_phyReg_get(port, devad, reg, &val);
 			snprintf(_buf_rd_phyreg_mmd, 64, "port: %d, devad: 0x%08x, reg: 0x%08x, val: 0x%08x\n", port, devad, reg, val);
 		}
 	} else {
 		snprintf(_buf_rd_phyreg_mmd, 64, "echo \"w/r <real_port_index> <devad> <reg> [<val>]\" > phyreg_mmd\n");
 	}
+	kfree(buf);
 	return count;
 }
 
@@ -113,20 +123,23 @@ ssize_t _reg_rw_write(struct file *filep, const char __user *ubuf,
 		return PTR_ERR(buf);
 
 	if(buf[0] == 'w') {
-		if(sscanf(buf, "w %x %x", &reg, &val) == -1)
+		if (sscanf(buf, "w %x %x", &reg, &val) != 2) {
+			kfree(buf);
 			return -EFAULT;
-		else
+		} else
 			rtk_rtl8373_setAsicReg(reg, val);
 	} else if(buf[0] == 'r') {
-		if(sscanf(buf, "r %x", &reg) == -1)
+		if (sscanf(buf, "r %x", &reg) != 1) {
+			kfree(buf);
 			return -EFAULT;
-		else {
+		} else {
 			rtk_rtl8373_getAsicReg(reg, &val);
 			snprintf(_buf_rd_reg, 64, "reg: 0x%08x, val: 0x%08x\n", reg, val);
 		}
 	} else {
 		snprintf(_buf_rd_reg, 64, "echo \"w/r <reg> [<val>]\" > reg\n");
 	}
+	kfree(buf);
 	return count;
 }
 


### PR DESCRIPTION
## Summary

Consolidate PRs #21 and #22 into one hardening change for the three debugfs register-write handlers.

The handlers now:

- require the exact number of parsed fields for each command;
- use unsigned conversions for the unsigned sds_id and port values;
- release the memdup_user_nul() buffer on normal and validation-error paths.

Valid command forms and register operations remain unchanged.

## Why this solution is believed to be correct

sscanf() returns the number of successful assignments, so checking only for -1 allowed partial input to reach register access code with uninitialized fields. Requiring the expected conversion count prevents that. Since the same validation paths return early, buffer lifetime must be reviewed at the same time; every post-allocation exit now releases the buffer.

## Review organization

While auditing PRs #10-#40, these changes were found to modify the same three write handlers and to interact directly at their early-return paths. They were therefore optimized into one review unit for easier verification and confirmation. This is a review-oriented consolidation; no new debugfs command or hardware operation is introduced.

## Validation

- git diff --check
- scripts/checkpatch.pl --no-tree --terse
- No full target build or Flint 3 hardware test was available in this environment.

## Review request

Please test valid read/write commands, empty and partial commands, out-of-range sds_id and port values, repeated writes, and the intended behavior for extra trailing fields.

## Confidence

Approximately 97% for the parser and allocation-lifetime changes. Runtime confirmation is requested for the debugfs interface and repeated-write behavior.