### PR TITLE
rtl837x: fix shared-meter IFG readback

### DIFF
--- a/package/kernel/rtl837x/src/rtk-api/dal/rtl8373/dal_rtl8373_sharemeter.c
+++ b/package/kernel/rtl837x/src/rtk-api/dal/rtl8373/dal_rtl8373_sharemeter.c
@@ -152,8 +152,6 @@ rtk_api_ret_t dal_rtl8373_rate_shareMeter_get(rtk_meter_id_t index, rtk_meter_ty
     if((retVal = rtl8373_getAsicRegBit(RTL8373_SHARED_METER_IPG_CTRL_ADDR(index), RTL8373_SHARED_METER_IPG_CTRL_IPG_CNTR_OFFSET(index), pIfg_include)) != RT_ERR_OK)
         return retVal;
 
-    *pIfg_include = (regData == 1) ? ENABLED : DISABLED;
-
     /* Type */
     if ((retVal = rtl8373_getAsicRegBit(RTL8373_SHARED_METER_MODE_ADDR(index), RTL8373_SHARED_METER_MODE_LB_MODE_OFFSET(index), &regData)) != RT_ERR_OK)
         return retVal;
@@ -780,6 +778,5 @@ rtk_api_ret_t dal_rtl8373_rate_egrQueueBwCtrlRate_set(rtk_port_t port, rtk_qid_t
 }
 
 #endif
-
 
 


### PR DESCRIPTION
## Summary

- stop overwriting the IFG value returned by the shared-meter register read
- keep `regData` exclusively for the meter type read

## Why this is correct

`dal_rtl8373_rate_shareMeter_get()` already reads the IFG bit directly into `pIfg_include` and checks the MDIO/SMI return value. The following assignment replaces that result with `regData` before `regData` is populated by the subsequent meter-mode read. This makes IFG readback depend on an unrelated, not-yet-read value and can report the wrong state. Removing the stale assignment preserves the checked hardware value and does not change any register writes or meter programming.

This is intentionally isolated from rate-policing and future storm-control work. It only corrects the existing shared-meter read path.

## Validation

- `git diff --check`
- reviewed the read order: IFG is read into `pIfg_include`; `regData` is then read for meter type
- hardware validation remains desirable on RTL8373, but is not required to establish the source-level bug

Please review the minimal fix and confirm the expected IFG register semantics on the RTL8373.