### PR TITLE
qualcommbe: document stock GL-BE9300 board identity

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,15 @@ Short version: from stock firmware, use the **factory** image with
 required and the "missing section" warnings for `u-boot`/`tz`/`sb11` are
 expected. Do **not** force the plain sysupgrade image from stock.
 
+Stock QSDK firmware may report `qcom,ipq5332-ap-mi01.6` as its board name.
+That is the generic Qualcomm MI01.6/RDP468 identity used by the vendor path,
+not the OpenWrt GL-BE9300 device identifier. The same compatible is used by
+the upstream Qualcomm RDP468 device tree, so it is intentionally not added to
+this profile's `SUPPORTED_DEVICES`: doing so would advertise the Flint 3 image
+as compatible with other hardware using that generic identity. The resulting
+stock compatibility warning is therefore expected; use the documented `-F`
+factory-image path instead (see [issue #9](https://github.com/perceival/openwrt-flint3/issues/9)).
+
 **Back up your eMMC first** — the ART partition holds this unit's radio
 calibration and MAC addresses and cannot be recovered from anywhere else.
 


### PR DESCRIPTION
## Summary

Document the stock-to-OpenWrt installation behavior for GL-BE9300 instead of
adding a broad board alias to the image compatibility list.

Stock GL-BE9300 firmware may report `qcom,ipq5332-ap-mi01.6` as its board
name. The upstream Qualcomm device tree uses that same compatible for the
IPQ5332 RDP468 reference board. It is therefore not a unique GL-BE9300
identifier and must not be added to this profile's `SUPPORTED_DEVICES` list.

## Why this is correct

Issue #9 shows the stock QSDK compatibility warning during the factory-image
installation. The warning is expected on this path: the stock firmware sees
its generic vendor board identity, while the OpenWrt image is built for the
GL-BE9300 profile. The documented `sysupgrade -F -n` invocation intentionally
bypasses that check for the QSDK factory wrapper; the missing vendor bootloader
sections are also expected because OpenWrt does not ship those payloads.

Accepting `qcom,ipq5332-ap-mi01.6` in `SUPPORTED_DEVICES` would instead claim
that the GL-BE9300 image is compatible with any hardware using that generic
identity, including the RDP468 reference board. This PR now documents the
distinction and leaves the compatibility list restricted to the canonical
GL-BE9300 identifiers.

## Validation

- Compared the stock identifier reported in issue #9 with the upstream Linux
  `ipq5332-rdp468.dts` compatible.
- Confirmed the final image-profile diff does not add the generic alias.
- `git diff --check`: passed.
- `scripts/checkpatch.pl --no-tree --terse`: passed.
- The final change is documentation-only from the profile's point of view and
  does not alter the device tree, image layout, or runtime networking.

No router was available here, so the installation procedure remains a
hardware-side check. Please review the wording against the validated stock
installation path and issue #9.
