### PR TITLE
rtl837x: clean probe state on initialization failure

### DIFF
--- a/package/kernel/rtl837x/src/rtl837x_mdio.c
+++ b/package/kernel/rtl837x/src/rtl837x_mdio.c
@@ -938,9 +938,9 @@ static int rtl837x_dsa_probe(struct mdio_device *mdiodev)
 	{
 		dev_err(gsw->dev, "rtl8372n_hw_init failed, ret=%d\n",ret);
 		rtl837x_clear_global_priv(gsw);
+		dev_set_drvdata(dev, NULL);
 		if (master)
 			dev_put(master);
-		devm_kfree(dev, gsw);
 		return -ENODEV;
 	}
 
@@ -951,9 +951,9 @@ static int rtl837x_dsa_probe(struct mdio_device *mdiodev)
 	if (ret){
 		dev_err(gsw->dev, "rtl837x_dsa_register failed, ret=%d\n", ret);
 		rtl837x_clear_global_priv(gsw);
+		dev_set_drvdata(dev, NULL);
 		if (master)
 			dev_put(master);
-		devm_kfree(dev, gsw);
 		return ret;
 	}
 


### PR DESCRIPTION
## Summary

Clean up the two RTL837x probe error paths that run after driver state has been installed:

- remove the manual `devm_kfree()` calls;
- clear `dev_set_drvdata()` before returning from probe failure.

The existing `rtl837x_clear_global_priv()` calls are retained.

## Why this is correct

`gsw` is allocated with devres, so probe failure already releases it during
normal devres unwinding. Calling `devm_kfree()` directly in the error path is
unnecessary. It is not an active use-after-free in the current code because
the regmap release path does not dereference `lock_arg`, but retaining a
manual free makes the lifetime assumptions fragile for future devm-managed
contexts created for the object. Removing it preserves the normal resource
lifetime.

The probe stores `gsw` in both the module-global private pointer and device
driver data before hardware initialization and DSA registration. The global
pointer is already cleared on these failures; clearing `drvdata` as well
prevents the failed device from retaining a pointer to probe state that will be
released by devres. This is defense in depth for the failed-probe path.

This is intentionally limited to probe cleanup. It does not change the error
policy, DSA registration order, hardware initialization, or normal remove path.

## Validation

- `git diff --check`: passed.
- `scripts/checkpatch.pl --no-tree --terse`: passed.
- Reviewed both failure paths against the devres allocation and the existing `rtl837x_clear_global_priv()` helper.
- Branch is based directly on the current `flint3-be9300` tip.
- The branch name intentionally has no `codex/` prefix.

No router was required to establish the lifetime and pointer-cleanup
correctness. Please review the devres ordering and confirm that both
failed-probe paths should use the same cleanup policy.
