### PR TITLE
rtl837x: avoid overriding bridge STP on port enable

### DIFF
--- a/package/kernel/rtl837x/src/rtl837x_common.h
+++ b/package/kernel/rtl837x/src/rtl837x_common.h
@@ -100,7 +100,6 @@ struct rtk_gsw {
 	bool dsa_registered;
 	struct dsa_switch ds;
 	struct net_device *bridge_dev[RTK_MAX_NUM_OF_PORT];
-	bool port_enabled[RTK_MAX_NUM_OF_PORT];
 	struct net_device *ethernet_master;
 	struct sfp_bus *sfp_bus;
 

--- a/package/kernel/rtl837x/src/rtl837x_dsa_ops.c
+++ b/package/kernel/rtl837x/src/rtl837x_dsa_ops.c
@@ -394,12 +394,10 @@ static int rtl837x_setup(struct dsa_switch *ds)
 		return ret;
 
 	memset(gsw->bridge_dev, 0, sizeof(gsw->bridge_dev));
-	memset(gsw->port_enabled, 0, sizeof(gsw->port_enabled));
 	memset(gsw->tag8021q_pvid, 0, sizeof(gsw->tag8021q_pvid));
 	memset(gsw->tag8021q_pvid_valid, 0, sizeof(gsw->tag8021q_pvid_valid));
 	memset(gsw->bridge_pvid, 0, sizeof(gsw->bridge_pvid));
 	memset(gsw->bridge_pvid_valid, 0, sizeof(gsw->bridge_pvid_valid));
-	gsw->port_enabled[gsw->cpu_port] = true;
 
 	for (port = 0; port < RTK_MAX_NUM_OF_PORT; port++) {
 		if (!rtl837x_valid_port(gsw, port))
@@ -741,33 +739,6 @@ static int rtl837x_set_ageing_time(struct dsa_switch *ds, unsigned int msecs)
 	return rtl837x_to_errno(rtk_l2_aging_set(secs));
 }
 
-static int rtl837x_port_enable(struct dsa_switch *ds, int port,
-			       struct phy_device *phy)
-{
-	struct rtk_gsw *gsw = ds->priv;
-
-	if (!rtl837x_valid_port(gsw, port))
-		return -EINVAL;
-
-	gsw->port_enabled[port] = true;
-
-	return rtl837x_set_stp_state(gsw, port, BR_STATE_FORWARDING);
-}
-
-static void rtl837x_port_disable(struct dsa_switch *ds, int port)
-{
-	struct rtk_gsw *gsw = ds->priv;
-	int ret;
-
-	if (!rtl837x_valid_port(gsw, port))
-		return;
-
-	gsw->port_enabled[port] = false;
-	ret = rtl837x_set_stp_state(gsw, port, BR_STATE_DISABLED);
-	if (ret)
-		dev_err(gsw->dev, "failed to disable port %d: %d\n", port, ret);
-}
-
 static void rtl837x_port_stp_state_set(struct dsa_switch *ds, int port,
 				       u8 state)
 {
@@ -996,8 +967,6 @@ static const struct dsa_switch_ops rtl837x_dsa_ops = {
 	.get_sset_count = rtl837x_get_sset_count,
 	.get_pause_stats = rtl837x_get_pause_stats,
 	.set_ageing_time = rtl837x_set_ageing_time,
-	.port_enable = rtl837x_port_enable,
-	.port_disable = rtl837x_port_disable,
 	.support_eee = rtl837x_support_eee,
 	.set_mac_eee = rtl837x_set_mac_eee,
 	.port_bridge_join = dsa_tag_8021q_bridge_join,


### PR DESCRIPTION
## Summary

Remove the RTL837x DSA driver callbacks that force ports to `BR_STATE_FORWARDING` during port enable and to `BR_STATE_DISABLED` during port disable.

The patch also removes the unused `port_enabled[]` state from `struct rtk_gsw` and its setup bookkeeping.

## Why this is correct

DSA already owns the port lifecycle and applies the generic STP state for standalone ports. For bridged ports, the bridge STP state is the authoritative state and must not be overwritten by a driver-level enable callback. The current callbacks therefore race with or override bridge-controlled STP transitions.

The driver still exposes `port_stp_state_set`, which is the appropriate DSA hook for programming hardware STP state. No hardware initialization, VLAN handling, link handling, or bridge bookkeeping is changed.

## Validation

- `git diff --check`: passed.
- `scripts/checkpatch.pl --no-tree --terse`: passed.
- Confirmed `port_enabled[]` had no readers and was only written by the removed callbacks and setup code.
- Reviewed the Linux 6.18 DSA port lifecycle: generic forwarding and disabled states are only applied when the port is not attached to a bridge.
- Branch is based directly on the current `flint3-be9300` tip.

No router was required for this control-flow and dead-state cleanup. Please review the STP ownership boundary and confirm that the existing `port_stp_state_set` path is sufficient for the supported topology.

## Package build validation

- make package/kernel/rtl837x/compile V=s: attempted on macOS with Apple make; stopped before package compilation because Apple make is unsupported.
- /opt/homebrew/bin/gmake package/kernel/rtl837x/compile V=s: stopped at OpenWrt prerequisite checks. The host lacks a case-sensitive filesystem and required GNU utilities, including coreutils, tar, find, patch, diff, awk, wget, and install.
- No successful package-build result is claimed; a Linux case-sensitive OpenWrt build host is still required.