### PR TITLE
rtl837x: keep VLAN filtering and PVID transitions consistent

### DIFF
--- a/package/kernel/rtl837x/src/rtl837x_dsa_ops.c
+++ b/package/kernel/rtl837x/src/rtl837x_dsa_ops.c
@@ -129,14 +129,14 @@ static int rtl837x_open_isolation(struct rtk_gsw *gsw)
 	return 0;
 }
 
-static int rtl837x_commit_pvid(struct rtk_gsw *gsw, int port)
+static int rtl837x_commit_pvid_for_mode(struct rtk_gsw *gsw, int port,
+					bool vlan_filtering)
 {
-	struct dsa_port *dp = dsa_to_port(&gsw->ds, port);
 	bool valid = gsw->tag8021q_pvid_valid[port];
 	u16 vid = gsw->tag8021q_pvid[port];
 	int ret;
 
-	if (dsa_port_is_vlan_filtering(dp)) {
+	if (vlan_filtering) {
 		vid = gsw->bridge_pvid[port];
 		valid = gsw->bridge_pvid_valid[port];
 	}
@@ -147,6 +147,14 @@ static int rtl837x_commit_pvid(struct rtk_gsw *gsw, int port)
 
 	gsw->port_pvid[port] = valid ? vid : 0;
 	return 0;
+}
+
+static int rtl837x_commit_pvid(struct rtk_gsw *gsw, int port)
+{
+	struct dsa_port *dp = dsa_to_port(&gsw->ds, port);
+
+	return rtl837x_commit_pvid_for_mode(gsw, port,
+					    dsa_port_is_vlan_filtering(dp));
 }
 
 static int rtl837x_set_stp_state(struct rtk_gsw *gsw, int port, u8 state)
@@ -805,17 +813,32 @@ static int rtl837x_port_vlan_filtering(struct dsa_switch *ds, int port,
 				       struct netlink_ext_ack *extack)
 {
 	struct rtk_gsw *gsw = ds->priv;
-	int ret;
+	struct dsa_port *dp;
+	bool old_vlan_filtering;
+	int ret, rollback_ret;
 
 	if (!rtl837x_user_port(gsw, port))
 		return 0;
+
+	dp = dsa_to_port(ds, port);
+	old_vlan_filtering = dsa_port_is_vlan_filtering(dp);
 
 	ret = rtk_vlan_portIgrFilterEnable_set(port,
 					       vlan_filtering ? ENABLED : DISABLED);
 	if (ret)
 		return rtl837x_to_errno(ret);
 
-	return rtl837x_commit_pvid(gsw, port);
+	ret = rtl837x_commit_pvid_for_mode(gsw, port, vlan_filtering);
+	if (ret) {
+		rollback_ret = rtk_vlan_portIgrFilterEnable_set(
+				port, old_vlan_filtering ? ENABLED : DISABLED);
+		if (rollback_ret)
+			dev_err(gsw->dev,
+				"failed to restore VLAN ingress filtering on port %d: %d\n",
+				port, rtl837x_to_errno(rollback_ret));
+	}
+
+	return ret;
 }
 
 static int rtl837x_port_vlan_add(struct dsa_switch *ds, int port,


### PR DESCRIPTION
## Summary

Make VLAN filtering transitions use the requested mode when selecting the PVID source, and restore the previous ingress-filtering state if the PVID update fails.

The existing PVID helper remains the compatibility wrapper for VLAN add and delete paths, while the transition path now passes the target mode explicitly.

## Why this is correct

DSA invokes the switch driver callback with the new `vlan_filtering` value before it updates the DSA port state. Reading `dsa_port_is_vlan_filtering()` inside that callback therefore describes the old mode. The old-mode read can select the tag_8021q PVID while enabling bridge VLAN filtering, or the bridge PVID while disabling it.

The callback now commits the PVID using the requested mode. If that commit fails after ingress filtering has already changed, the driver attempts to restore the old ingress-filtering setting and returns the original PVID error. A failed rollback is reported explicitly. VLAN shadow state is updated only after the PVID write succeeds.

This is intentionally limited to the transition ordering and rollback. It does not change VLAN table membership, tag_8021q VID allocation, or the normal VLAN add and delete paths.

## Validation

- `git diff --check`: passed.
- `scripts/checkpatch.pl --no-tree --terse`: passed.
- Reviewed the Linux 6.18 DSA callback ordering and confirmed that the callback receives the requested mode before `dp->vlan_filtering` is updated.
- Confirmed existing VLAN add and delete callers retain the current-state wrapper.
- Branch is based directly on the current `flint3-be9300` tip.

No router was required for this state-ordering and rollback fix. Please review the failure sequence and confirm that restoring ingress filtering is the desired hardware rollback when the PVID write fails.

## Package build validation

- make package/kernel/rtl837x/compile V=s: attempted on macOS with Apple make; stopped before package compilation because Apple make is unsupported.
- /opt/homebrew/bin/gmake package/kernel/rtl837x/compile V=s: stopped at OpenWrt prerequisite checks. The host lacks a case-sensitive filesystem and required GNU utilities, including coreutils, tar, find, patch, diff, awk, wget, and install.
- No successful package-build result is claimed; a Linux case-sensitive OpenWrt build host is still required.