### PR TITLE
rtl837x: propagate debugfs register access errors

### DIFF
--- a/package/kernel/rtl837x/src/rtl837x_dbg.c
+++ b/package/kernel/rtl837x/src/rtl837x_dbg.c
@@ -9,6 +9,7 @@
 #include <linux/proc_fs.h>
 #include <linux/u64_stats_sync.h>
 #include <linux/slab.h>
+#include <linux/errno.h>
 
 #include "./rtl837x_common.h"
 
@@ -43,6 +44,7 @@ ssize_t _sdsreg_rw_write(struct file *filep, const char __user *ubuf,
 {
 	char *buf;
 	uint32_t sds_id, page, reg, val;
+	int ret;
 
 	buf = memdup_user_nul(ubuf, count);
 	if (IS_ERR(buf))
@@ -57,14 +59,26 @@ ssize_t _sdsreg_rw_write(struct file *filep, const char __user *ubuf,
 				kfree(buf);
 				return -EFAULT;
 			}
-			rtk_rtl8373_sds_reg_write(sds_id, page, reg, val);
+			ret = rtk_rtl8373_sds_reg_write(sds_id, page, reg, val);
+			if (ret) {
+				kfree(buf);
+				return -EIO;
+			}
 		}
 	} else if(buf[0] == 'r') {
 		if (sscanf(buf, "r %u %x %x", &sds_id, &page, &reg) != 3) {
 			kfree(buf);
 			return -EFAULT;
 		} else {
-			rtk_rtl8373_sds_reg_read(sds_id, page, reg, &val);
+			if (sds_id > 1) {
+				kfree(buf);
+				return -EFAULT;
+			}
+			ret = rtk_rtl8373_sds_reg_read(sds_id, page, reg, &val);
+			if (ret) {
+				kfree(buf);
+				return -EIO;
+			}
 			snprintf(_buf_rd_sdsreg, 64, "sds_id: %d, page: 0x%08x, reg: 0x%08x, val: 0x%08x\n", sds_id, page, reg, val);
 		}
 	} else {
@@ -79,6 +93,7 @@ ssize_t _phyreg_mmd_rw_write(struct file *filep, const char __user *ubuf,
 {
 	char *buf;
 	uint32_t port, devad, reg, val;
+	int ret;
 
 	buf = memdup_user_nul(ubuf, count);
 	if (IS_ERR(buf))
@@ -93,14 +108,26 @@ ssize_t _phyreg_mmd_rw_write(struct file *filep, const char __user *ubuf,
 				kfree(buf);
 				return -EFAULT;
 			}
-			rtk_port_phyReg_set(1<<port, devad, reg, val);
+			ret = rtk_port_phyReg_set(1 << port, devad, reg, val);
+			if (ret) {
+				kfree(buf);
+				return -EIO;
+			}
 		}
 	} else if(buf[0] == 'r') {
 		if (sscanf(buf, "r %u %x %x", &port, &devad, &reg) != 3) {
 			kfree(buf);
 			return -EFAULT;
 		} else {
-			rtk_port_phyReg_get(port, devad, reg, &val);
+			if (port > 9) {
+				kfree(buf);
+				return -EFAULT;
+			}
+			ret = rtk_port_phyReg_get(port, devad, reg, &val);
+			if (ret) {
+				kfree(buf);
+				return -EIO;
+			}
 			snprintf(_buf_rd_phyreg_mmd, 64, "port: %d, devad: 0x%08x, reg: 0x%08x, val: 0x%08x\n", port, devad, reg, val);
 		}
 	} else {
@@ -115,6 +142,7 @@ ssize_t _reg_rw_write(struct file *filep, const char __user *ubuf,
 {
 	char *buf;
 	uint32_t reg, val;
+	int ret;
 	if (*offp)
 		return 0;
 
@@ -126,14 +154,23 @@ ssize_t _reg_rw_write(struct file *filep, const char __user *ubuf,
 		if (sscanf(buf, "w %x %x", &reg, &val) != 2) {
 			kfree(buf);
 			return -EFAULT;
-		} else
-			rtk_rtl8373_setAsicReg(reg, val);
+		} else {
+			ret = rtk_rtl8373_setAsicReg(reg, val);
+			if (ret) {
+				kfree(buf);
+				return -EIO;
+			}
+		}
 	} else if(buf[0] == 'r') {
 		if (sscanf(buf, "r %x", &reg) != 1) {
 			kfree(buf);
 			return -EFAULT;
 		} else {
-			rtk_rtl8373_getAsicReg(reg, &val);
+			ret = rtk_rtl8373_getAsicReg(reg, &val);
+			if (ret) {
+				kfree(buf);
+				return -EIO;
+			}
 			snprintf(_buf_rd_reg, 64, "reg: 0x%08x, val: 0x%08x\n", reg, val);
 		}
 	} else {

--- a/package/kernel/rtl837x/src/rtl837x_dbg.c
+++ b/package/kernel/rtl837x/src/rtl837x_dbg.c
@@ -46,6 +46,7 @@ ssize_t _sdsreg_rw_write(struct file *filep, const char __user *ubuf,
 	uint32_t sds_id, page, reg, val;
 	int ret;
 
+	_buf_rd_sdsreg[0] = '\0';
 	buf = memdup_user_nul(ubuf, count);
 	if (IS_ERR(buf))
 		return PTR_ERR(buf);
@@ -95,6 +96,7 @@ ssize_t _phyreg_mmd_rw_write(struct file *filep, const char __user *ubuf,
 	uint32_t port, devad, reg, val;
 	int ret;
 
+	_buf_rd_phyreg_mmd[0] = '\0';
 	buf = memdup_user_nul(ubuf, count);
 	if (IS_ERR(buf))
 		return PTR_ERR(buf);
@@ -143,6 +145,9 @@ ssize_t _reg_rw_write(struct file *filep, const char __user *ubuf,
 	char *buf;
 	uint32_t reg, val;
 	int ret;
+
+	_buf_rd_reg[0] = '\0';
+
 	if (*offp)
 		return 0;
 


### PR DESCRIPTION
## Summary

Return an error to userspace when RTL837x debugfs register, PHY-MMD, or SerDes
access fails instead of reporting a successful write or formatting an invalid
read value.

The patch also validates the SerDes ID and PHY port on both read and write
paths, keeping the existing input-error behavior for malformed requests.

## Why this is correct

The debugfs handlers call the vendor SDK directly, but the previous
implementation ignored return values from all register access operations. A
failed MDIO transaction could therefore appear successful to the caller, and a
failed read could expose an uninitialized or stale value in the readback
buffer.

Each hardware operation now checks its return value, frees the userspace
buffer, and returns `-EIO` on an SDK failure. Invalid SerDes and PHY indices
are rejected symmetrically before accessing the SDK. Readback buffers are
cleared before each new command, so a malformed command, failed read, or
failed userspace copy cannot expose the previous successful read result. The
`port > 9` check is the explicit RTL837x debug-interface capability limit, not
a substitute for a buffer-safety check. The existing SerDes page dump path
already propagates its access failures and is left unchanged.

This is intentionally limited to debugfs error reporting and bounds
validation. It does not change the vendor register format, command syntax, or
normal DSA paths.

## Validation

- `git diff --check`: passed.
- `scripts/checkpatch.pl --no-tree --terse`: passed.
- Confirmed all six direct register access calls in the three write handlers now have checked return values.
- Confirmed readback formatting occurs only after a successful hardware read.
- Confirmed failed commands clear the corresponding readback buffer.
- Confirmed the existing page-dump error path remains intact.
- Branch is based directly on the current `flint3-be9300` tip.

No router was required for this userspace error-path fix. Please review the
errno choice and the symmetric index validation.

## Package build validation

- make package/kernel/rtl837x/compile V=s: attempted on macOS with Apple make; stopped before package compilation because Apple make is unsupported.
- /opt/homebrew/bin/gmake package/kernel/rtl837x/compile V=s: stopped at OpenWrt prerequisite checks. The host lacks a case-sensitive filesystem and required GNU utilities, including coreutils, tar, find, patch, diff, awk, wget, and install.
- No successful package-build result is claimed; a Linux case-sensitive OpenWrt build host is still required.
