### PR TITLE
rtl837x: return Linux errno from MDIO regmap callbacks

### DIFF
--- a/package/kernel/rtl837x/src/rtl837x_mdio.c
+++ b/package/kernel/rtl837x/src/rtl837x_mdio.c
@@ -90,8 +90,8 @@ static int rtl837x_mdio_write(void *ctx, u32 reg, u32 val)
 	if (ret < 0)
 		goto out_unlock;
 
-    if (ret & 0x4) {
-		ret = RT_ERR_BUSYWAIT_TIMEOUT;
+	if (ret & 0x4) {
+		ret = -ETIMEDOUT;
 		goto out_unlock;
     }
 
@@ -116,8 +116,8 @@ static int rtl837x_mdio_write(void *ctx, u32 reg, u32 val)
 	if (ret < 0)
 		goto out_unlock;
 
-    if (ret & 0x4) {
-		ret = RT_ERR_BUSYWAIT_TIMEOUT;
+	if (ret & 0x4) {
+		ret = -ETIMEDOUT;
 		goto out_unlock;
     }
 	ret = 0;
@@ -140,8 +140,8 @@ static int rtl837x_mdio_read(void *ctx, u32 reg, u32 *val)
 	if (ret < 0)
 		goto out_unlock;
 
-    if (ret & 0x4) {
-		ret = RT_ERR_BUSYWAIT_TIMEOUT;
+	if (ret & 0x4) {
+		ret = -ETIMEDOUT;
 		goto out_unlock;
     }
 
@@ -158,8 +158,8 @@ static int rtl837x_mdio_read(void *ctx, u32 reg, u32 *val)
 	if (ret < 0)
 		goto out_unlock;
 
-    if (ret & 0x4) {
-		ret = RT_ERR_BUSYWAIT_TIMEOUT;
+	if (ret & 0x4) {
+		ret = -ETIMEDOUT;
 		goto out_unlock;
     }
 

--- a/package/kernel/rtl837x/src/rtl837x_mdio.c
+++ b/package/kernel/rtl837x/src/rtl837x_mdio.c
@@ -93,7 +93,7 @@ static int rtl837x_mdio_write(void *ctx, u32 reg, u32 val)
 	if (ret & 0x4) {
 		ret = -ETIMEDOUT;
 		goto out_unlock;
-    }
+	}
 
 	ret = bus->write(bus, priv->mdio_addr, MDC_MDIO_ADDR_REG, reg);
 	if (ret)
@@ -119,7 +119,7 @@ static int rtl837x_mdio_write(void *ctx, u32 reg, u32 val)
 	if (ret & 0x4) {
 		ret = -ETIMEDOUT;
 		goto out_unlock;
-    }
+	}
 	ret = 0;
 out_unlock:
 	mutex_unlock(&bus->mdio_lock);
@@ -143,7 +143,7 @@ static int rtl837x_mdio_read(void *ctx, u32 reg, u32 *val)
 	if (ret & 0x4) {
 		ret = -ETIMEDOUT;
 		goto out_unlock;
-    }
+	}
 
 	ret = bus->write(bus, priv->mdio_addr, MDC_MDIO_ADDR_REG, reg);
 	if (ret)
@@ -161,7 +161,7 @@ static int rtl837x_mdio_read(void *ctx, u32 reg, u32 *val)
 	if (ret & 0x4) {
 		ret = -ETIMEDOUT;
 		goto out_unlock;
-    }
+	}
 
 
 	val_l = bus->read(bus, priv->mdio_addr, MDC_MDIO_DATA_LOW);


### PR DESCRIPTION
## Summary

Translate the RTL837x MDIO busy timeout into the Linux `-ETIMEDOUT` errno in
all regmap read and write callback paths.

The existing negative errors returned by the underlying MDIO bus are preserved
unchanged.

## Why this is correct

The regmap callbacks return Linux-style negative errno values to their callers.
`RT_ERR_BUSYWAIT_TIMEOUT` is a positive vendor SDK status code, so returning it
directly violates the callback contract; current callers test nonzero results,
but a positive value can be misinterpreted by other Linux consumers as a
successful or otherwise invalid result.

The timeout condition is now reported as `-ETIMEDOUT` for both the
pre-operation and post-operation busy checks in read and write callbacks.
Bus-level failures continue to pass through, preserving the more specific
error reported by the MDIO bus.

This is intentionally limited to the regmap boundary. It does not alter the
MDIO transaction sequence, locking, timeout detection, or vendor SDK status
handling elsewhere in the driver.

## Validation

- `git diff --check`: passed.
- `scripts/checkpatch.pl --no-tree --terse`: passed.
- Confirmed all four busy-timeout assignments in `rtl837x_mdio_read` and `rtl837x_mdio_write` now return `-ETIMEDOUT`.
- Confirmed negative MDIO bus errors remain unchanged.
- Branch is based directly on the current `flint3-be9300` tip.

No router was required for this errno translation. Please review the regmap
callback contract and timeout propagation.

## Package build validation

- make package/kernel/rtl837x/compile V=s: attempted on macOS with Apple make; stopped before package compilation because Apple make is unsupported.
- /opt/homebrew/bin/gmake package/kernel/rtl837x/compile V=s: stopped at OpenWrt prerequisite checks. The host lacks a case-sensitive filesystem and required GNU utilities, including coreutils, tar, find, patch, diff, awk, wget, and install.
- No successful package-build result is claimed; a Linux case-sensitive OpenWrt build host is still required.
