### PR TITLE
rtl837x: use SGMII SerDes mode for SGMII SFP modules

### DIFF
--- a/package/kernel/rtl837x/src/rtl837x_mdio.c
+++ b/package/kernel/rtl837x/src/rtl837x_mdio.c
@@ -678,8 +678,10 @@ static int rtl837x_sfp_module_insert(void *upstream, const struct sfp_eeprom_id 
 		USE_SERDESMODE(1, SERDES_2500BASEX);
 		break;
 	case PHY_INTERFACE_MODE_1000BASEX:
-	case PHY_INTERFACE_MODE_SGMII:
 		USE_SERDESMODE(1, SERDES_1000BASEX);
+		break;
+	case PHY_INTERFACE_MODE_SGMII:
+		USE_SERDESMODE(1, SERDES_SG);
 		break;
 	case PHY_INTERFACE_MODE_100BASEX:
 		USE_SERDESMODE(1, SERDES_100FX);


### PR DESCRIPTION
## Summary

Select the dedicated `SERDES_SG` mode when the SFP layer identifies an
inserted module as SGMII.

Keep `SERDES_1000BASEX` for 1000BASE-X modules and leave the existing handling
for 10G, 2.5G, 100M, and unsupported interfaces unchanged.

## Why this is correct

The RTL837x SDK distinguishes SGMII (`SERDES_SG`) from 1000BASE-X
(`SERDES_1000BASEX`). The previous switch statement grouped both Linux
interface modes and therefore configured an SGMII SFP as 1000BASE-X.

The interface selection result is now mapped one-to-one to the corresponding
SDK SerDes mode. Existing force-mode handling remains unchanged. If
`rtk_sdsMode_set()` fails, the callback restores the cached `sds1mode` value;
it does not claim a hardware rollback, which remains outside this narrow
mapping fix.

This is intentionally limited to SFP module insertion. It does not change
device-tree mode parsing, link negotiation, SFP removal, or other SerDes
transitions.

## Validation

- `git diff --check`: passed.
- `scripts/checkpatch.pl --no-tree --terse`: passed.
- Confirmed the SDK defines distinct `SERDES_SG` and `SERDES_1000BASEX` modes.
- Confirmed only the SGMII case changes; 1000BASE-X retains its existing mode.
- Branch is based directly on the current `flint3-be9300` tip.

No router or SFP module was available here, so hardware link-up remains a
device-side check. Please review the Linux-interface to SDK-SerDes mapping.

## Package build validation

- make package/kernel/rtl837x/compile V=s: attempted on macOS with Apple make; stopped before package compilation because Apple make is unsupported.
- /opt/homebrew/bin/gmake package/kernel/rtl837x/compile V=s: stopped at OpenWrt prerequisite checks. The host lacks a case-sensitive filesystem and required GNU utilities, including coreutils, tar, find, patch, diff, awk, wget, and install.
- No successful package-build result is claimed; a Linux case-sensitive OpenWrt build host is still required.
