### PR TITLE
rtl837x: isolate FDB entries by tag_8021q database

### DIFF
--- a/package/kernel/rtl837x/src/rtl837x_dsa_ops.c
+++ b/package/kernel/rtl837x/src/rtl837x_dsa_ops.c
@@ -800,6 +800,25 @@ static void rtl837x_port_fast_age(struct dsa_switch *ds, int port)
 			ret);
 }
 
+static int rtl837x_fdb_vid(u16 vid, struct dsa_db db, u16 *fdb_vid)
+{
+	if (vid) {
+		*fdb_vid = vid;
+		return 0;
+	}
+
+	switch (db.type) {
+	case DSA_DB_PORT:
+		*fdb_vid = dsa_tag_8021q_standalone_vid(db.dp);
+		return 0;
+	case DSA_DB_BRIDGE:
+		*fdb_vid = dsa_tag_8021q_bridge_vid(db.bridge.num);
+		return 0;
+	default:
+		return -EOPNOTSUPP;
+	}
+}
+
 static int rtl837x_port_vlan_filtering(struct dsa_switch *ds, int port,
 				       bool vlan_filtering,
 				       struct netlink_ext_ack *extack)
@@ -936,6 +955,7 @@ static int rtl837x_port_fdb_add(struct dsa_switch *ds, int port,
 	struct rtk_gsw *gsw = ds->priv;
 	rtk_l2_ucastAddr_t l2 = { 0 };
 	rtk_mac_t mac = { 0 };
+	u16 fdb_vid;
 	int ret;
 
 	if (!rtl837x_valid_port(gsw, port))
@@ -945,10 +965,14 @@ static int rtl837x_port_fdb_add(struct dsa_switch *ds, int port,
 	if (gsw->chip_id == CHIP_RTL8372N && port == gsw->cpu_port)
 		return 0;
 
+	ret = rtl837x_fdb_vid(vid, db, &fdb_vid);
+	if (ret)
+		return ret;
+
 	memcpy(mac.octet, addr, ETH_ALEN);
 	memcpy(l2.mac.octet, addr, ETH_ALEN);
-	l2.ivl = vid ? 1 : 0;
-	l2.vid_fid = vid;
+	l2.ivl = fdb_vid ? 1 : 0;
+	l2.vid_fid = fdb_vid;
 	l2.port = port;
 	l2.auth = 1;
 	l2.is_static = 1;
@@ -964,6 +988,7 @@ static int rtl837x_port_fdb_del(struct dsa_switch *ds, int port,
 	struct rtk_gsw *gsw = ds->priv;
 	rtk_l2_ucastAddr_t l2 = { 0 };
 	rtk_mac_t mac = { 0 };
+	u16 fdb_vid;
 	int ret;
 
 	if (!rtl837x_valid_port(gsw, port))
@@ -972,10 +997,14 @@ static int rtl837x_port_fdb_del(struct dsa_switch *ds, int port,
 	if (gsw->chip_id == CHIP_RTL8372N && port == gsw->cpu_port)
 		return 0;
 
+	ret = rtl837x_fdb_vid(vid, db, &fdb_vid);
+	if (ret)
+		return ret;
+
 	memcpy(mac.octet, addr, ETH_ALEN);
 	memcpy(l2.mac.octet, addr, ETH_ALEN);
-	l2.ivl = vid ? 1 : 0;
-	l2.vid_fid = vid;
+	l2.ivl = fdb_vid ? 1 : 0;
+	l2.vid_fid = fdb_vid;
 	l2.port = port;
 	l2.is_static = 1;
 


### PR DESCRIPTION
## Summary

Translate zero-VLAN FDB operations into the reserved tag_8021q VID for the target DSA database.

- Standalone port databases use `dsa_tag_8021q_standalone_vid()`.
- Bridge databases use `dsa_tag_8021q_bridge_vid()`.
- Unsupported database types return `-EOPNOTSUPP` when no explicit VLAN ID is supplied.

The translated VID is used consistently for both the IVL flag and the hardware FDB key.

## Why this is correct

With tag_8021q, a zero `vid` in a DSA FDB callback identifies the database context rather than a literal hardware VLAN. The RTL837x driver previously programmed all such entries with VID/FID zero, so standalone and bridge entries could share the same hardware lookup domain despite `ds->fdb_isolation` being enabled.

The driver now maps the DSA database context to the same reserved management VID scheme used by tag_8021q. Explicit nonzero VLAN IDs remain unchanged. Add and delete use the same translation, preserving key symmetry, and the existing CPU-port shortcut is retained.

This is intentionally limited to unicast FDB key construction. It does not change VLAN allocation, bridge membership, CPU flooding, multicast handling, or the existing `fdb_isolation` declaration.

## Validation

- `git diff --check`: passed.
- `scripts/checkpatch.pl --no-tree --terse`: passed.
- Confirmed DSA `struct dsa_db` supports the standalone-port and bridge database contexts used by this driver.
- Confirmed the tag_8021q standalone and bridge VID helpers are available to the current 6.18 target.
- Confirmed add and delete construct identical translated keys.
- Branch is based directly on the current `flint3-be9300` tip.

No router was required for this key-mapping fix. Please review the database-to-VID mapping and the unsupported database behavior.

## Package build validation

- make package/kernel/rtl837x/compile V=s: attempted on macOS with Apple make; stopped before package compilation because Apple make is unsupported.
- /opt/homebrew/bin/gmake package/kernel/rtl837x/compile V=s: stopped at OpenWrt prerequisite checks. The host lacks a case-sensitive filesystem and required GNU utilities, including coreutils, tar, find, patch, diff, awk, wget, and install.
- No successful package-build result is claimed; a Linux case-sensitive OpenWrt build host is still required.