### PR TITLE
rtl837x: reject multiple switch instances

### DIFF
--- a/package/kernel/rtl837x/src/rtl837x_mdio.c
+++ b/package/kernel/rtl837x/src/rtl837x_mdio.c
@@ -888,10 +888,28 @@ static const struct of_device_id rtk_gsw_match[] = {
 
 MODULE_DEVICE_TABLE(of, rtk_gsw_match);
 
+static DEFINE_MUTEX(rtl837x_instance_lock);
+
+static int rtl837x_claim_global_priv(struct rtk_gsw *gsw)
+{
+	int ret = 0;
+
+	mutex_lock(&rtl837x_instance_lock);
+	if (rtl_gbl_priv)
+		ret = -EBUSY;
+	else
+		rtl_gbl_priv = gsw;
+	mutex_unlock(&rtl837x_instance_lock);
+
+	return ret;
+}
+
 static void rtl837x_clear_global_priv(struct rtk_gsw *gsw)
 {
+	mutex_lock(&rtl837x_instance_lock);
 	if (rtl_gbl_priv == gsw)
 		rtl_gbl_priv = NULL;
+	mutex_unlock(&rtl837x_instance_lock);
 }
 
 static int rtl837x_dsa_probe(struct mdio_device *mdiodev)
@@ -1029,8 +1047,15 @@ static int rtl837x_dsa_probe(struct mdio_device *mdiodev)
 	dev_info(gsw->dev, "rtl837x dev info:smi-addr:%d configured-cpu-port:%u serdes-mode:%d swap_cfg:0x%x\n",
 						 gsw->mdio_addr, gsw->cpu_port, gsw->sds0mode, *(uint8_t*)&(gsw->swap_cfg));
 
+	ret = rtl837x_claim_global_priv(gsw);
+	if (ret) {
+		dev_err(dev, "another RTL837x switch instance is already active\n");
+		if (master)
+			dev_put(master);
+		return ret;
+	}
+
 	dev_set_drvdata(dev, gsw);
-	rtl_gbl_priv = gsw;
 
 	ret = rtl8372n_hw_init(gsw, gsw->swap_cfg);
 	if (ret)
@@ -1108,6 +1133,7 @@ static void rtl837x_mdio_shutdown(struct mdio_device *mdiodev)
 		gsw->ethernet_master = NULL;
 	}
 
+	rtl837x_clear_global_priv(gsw);
 	dev_set_drvdata(&mdiodev->dev, NULL);
 }
 

--- a/package/kernel/rtl837x/src/rtl837x_mdio.c
+++ b/package/kernel/rtl837x/src/rtl837x_mdio.c
@@ -1133,7 +1133,6 @@ static void rtl837x_mdio_shutdown(struct mdio_device *mdiodev)
 		gsw->ethernet_master = NULL;
 	}
 
-	rtl837x_clear_global_priv(gsw);
 	dev_set_drvdata(&mdiodev->dev, NULL);
 }
 


### PR DESCRIPTION
## Summary

Protect the vendor SDK global private pointer and reject a second RTL837x
switch probe while another instance is active.

The claim and release paths are serialized by a mutex. The claim is made
before hardware initialization. Normal remove releases the global pointer;
shutdown deliberately keeps ownership until remove because associated
debugfs, SFP, GPIO, and DSA state may still reference the switch context.

## Why this is correct

The RTL837x SDK uses global state, including `rtl_gbl_priv`, for register-map
access and mapper operations. The driver previously assigned that pointer
unconditionally during probe, so a second switch instance could silently
redirect SDK accesses to the newer device and leave the first instance using
the wrong context.

The driver now atomically checks and claims the global context, returning
`-EBUSY` when another instance owns it. Cleanup only clears the pointer when
it still belongs to the same switch, preventing one instance from clearing
another instance's ownership. The claim is placed before the first hardware
initialization call. If the claim fails, any acquired master-netdev reference
is released; failures after the claim clear the ownership and retain the
devres-safe probe cleanup from the base branch.

PR #52, which provides that devres-safe failed-probe cleanup, has been merged
into `flint3-be9300`. This branch is rebased onto
`79d086e797e60c0dfb195d4556a5bf5ad1332fc8` and contains only the remaining
singleton ownership guard; the #52 cleanup is inherited from the base and is
not duplicated here.

This is intentionally limited to global-instance ownership. It does not
refactor the vendor SDK globals, change normal DSA registration, or alter
hardware configuration.

## Validation

- `git diff --check`: passed.
- `scripts/checkpatch.pl --no-tree --terse`: passed.
- Final diff: 1 file changed, 26 insertions, 1 deletion.
- Confirmed `rtl_gbl_priv` is claimed before `rtl8372n_hw_init()`, the first
  hardware/SDK initialization call.
- Confirmed a second probe returns `-EBUSY` without overwriting the active
  pointer and releases its master-netdev reference.
- Confirmed normal remove clears only its own pointer and
  `rtl837x_mdio_shutdown()` does not clear global ownership.
- Confirmed the final diff contains only singleton ownership logic; the
  failed-probe cleanup is inherited from #52.

## Package build validation

- `make package/kernel/rtl837x/compile V=s`: attempted in the isolated
  worktree on macOS; OpenWrt stopped before package compilation because the
  Apple-provided GNU Make 3.81 is unsupported.
- No successful package-build result is claimed; a Linux case-sensitive
  OpenWrt build host is still required.
- No hardware validation was performed.

