### PR TITLE
rtl837x: offload bridge flood flags

### DIFF
--- a/package/kernel/rtl837x/src/rtl837x_common.h
+++ b/package/kernel/rtl837x/src/rtl837x_common.h
@@ -98,6 +98,7 @@ struct rtk_gsw {
 	struct regmap		*map;
 	struct regmap		*map_nolock;
 	struct mutex		map_lock;
+	struct mutex		flood_lock;
 
 	struct gpio_desc *reset_pin;
 	int mdio_addr;

--- a/package/kernel/rtl837x/src/rtl837x_dsa_ops.c
+++ b/package/kernel/rtl837x/src/rtl837x_dsa_ops.c
@@ -74,7 +74,109 @@ static int rtl837x_set_hairpin(struct rtk_gsw *gsw, int port, bool enable)
 }
 
 #define RTL837X_SUPPORTED_BRIDGE_FLAGS \
-	(BR_LEARNING | BR_HAIRPIN_MODE | BR_ISOLATED)
+	(BR_LEARNING | BR_HAIRPIN_MODE | BR_ISOLATED | BR_FLOOD | \
+	 BR_MCAST_FLOOD | BR_BCAST_FLOOD)
+
+struct rtl837x_flood_mask_update {
+	rtk_l2_flood_type_t type;
+	rtk_portmask_t old;
+	rtk_portmask_t new;
+	bool valid;
+	bool attempted;
+};
+
+static int rtl837x_flood_mask_update_prepare(
+		struct rtl837x_flood_mask_update *update, int port, bool enable)
+{
+	rtk_api_ret_t ret;
+
+	ret = rtk_l2_floodPortMask_get(update->type, &update->old);
+	if (ret != RT_ERR_OK)
+		return rtl837x_to_errno(ret);
+
+	update->new = update->old;
+	if (enable)
+		RTK_PORTMASK_PORT_SET(update->new, port);
+	else
+		RTK_PORTMASK_PORT_CLEAR(update->new, port);
+
+	update->valid = true;
+	return 0;
+}
+
+static void rtl837x_flood_mask_rollback(struct rtk_gsw *gsw,
+					struct rtl837x_flood_mask_update *updates,
+					unsigned int count)
+{
+	unsigned int i;
+	rtk_api_ret_t ret;
+
+	for (i = 0; i < count; i++) {
+		if (!updates[i].valid || !updates[i].attempted)
+			continue;
+
+		ret = rtk_l2_floodPortMask_set(updates[i].type,
+						       &updates[i].old);
+		if (ret != RT_ERR_OK)
+			dev_warn(gsw->dev,
+				 "failed to rollback flood mask type %u: %d\n",
+				 updates[i].type, rtl837x_to_errno(ret));
+	}
+}
+
+static int rtl837x_set_bridge_flood_flags(struct rtk_gsw *gsw, int port,
+						struct switchdev_brport_flags flags)
+{
+	struct rtl837x_flood_mask_update updates[] = {
+		{ .type = FLOOD_UNKNOWNDA },
+		{ .type = FLOOD_UNKNOWNL2MC },
+		{ .type = FLOOD_UNKNOWNV4MC },
+		{ .type = FLOOD_UNKNOWNV6MC },
+		{ .type = FLOOD_BC },
+	};
+	unsigned int i;
+	int ret;
+
+	if (flags.mask & BR_FLOOD) {
+		ret = rtl837x_flood_mask_update_prepare(&updates[0], port,
+							flags.val & BR_FLOOD);
+		if (ret)
+			return ret;
+	}
+
+	if (flags.mask & BR_MCAST_FLOOD) {
+		for (i = 1; i <= 3; i++) {
+			ret = rtl837x_flood_mask_update_prepare(&updates[i], port,
+								flags.val & BR_MCAST_FLOOD);
+			if (ret)
+				return ret;
+		}
+	}
+
+	if (flags.mask & BR_BCAST_FLOOD) {
+		ret = rtl837x_flood_mask_update_prepare(&updates[4], port,
+							flags.val & BR_BCAST_FLOOD);
+		if (ret)
+			return ret;
+	}
+
+	for (i = 0; i < ARRAY_SIZE(updates); i++) {
+		if (!updates[i].valid ||
+		    updates[i].old.bits[0] == updates[i].new.bits[0])
+			continue;
+
+		updates[i].attempted = true;
+		ret = rtl837x_to_errno(rtk_l2_floodPortMask_set(updates[i].type,
+									&updates[i].new));
+		if (ret) {
+			rtl837x_flood_mask_rollback(gsw, updates,
+							ARRAY_SIZE(updates));
+			return ret;
+		}
+	}
+
+	return 0;
+}
 
 static int rtl837x_apply_isolation(struct rtk_gsw *gsw,
 					   u32 isolated_port_mask,
@@ -103,6 +205,7 @@ static int rtl837x_port_bridge_flags(struct dsa_switch *ds, int port,
 					 struct switchdev_brport_flags flags,
 					 struct netlink_ext_ack *extack)
 {
+	struct rtk_gsw *gsw = ds->priv;
 	int ret;
 
 	ret = rtl837x_port_pre_bridge_flags(ds, port, flags, extack);
@@ -110,21 +213,28 @@ static int rtl837x_port_bridge_flags(struct dsa_switch *ds, int port,
 		return ret;
 
 	if (flags.mask & BR_LEARNING) {
-		ret = rtl837x_set_learning(ds->priv, port,
+		ret = rtl837x_set_learning(gsw, port,
 					    flags.val & BR_LEARNING);
 		if (ret)
 			return ret;
 	}
 
 	if (flags.mask & BR_HAIRPIN_MODE) {
-		ret = rtl837x_set_hairpin(ds->priv, port,
+		ret = rtl837x_set_hairpin(gsw, port,
 					   flags.val & BR_HAIRPIN_MODE);
 		if (ret)
 			return ret;
 	}
 
+	if (flags.mask & (BR_FLOOD | BR_MCAST_FLOOD | BR_BCAST_FLOOD)) {
+		mutex_lock(&gsw->flood_lock);
+		ret = rtl837x_set_bridge_flood_flags(gsw, port, flags);
+		mutex_unlock(&gsw->flood_lock);
+		if (ret)
+			return ret;
+	}
+
 	if (flags.mask & BR_ISOLATED) {
-		struct rtk_gsw *gsw = ds->priv;
 		u32 isolated_port_mask;
 
 		mutex_lock(&gsw->isolation_lock);

--- a/package/kernel/rtl837x/src/rtl837x_mdio.c
+++ b/package/kernel/rtl837x/src/rtl837x_mdio.c
@@ -946,6 +946,7 @@ static int rtl837x_dsa_probe(struct mdio_device *mdiodev)
 	}
 
 	mutex_init(&gsw->map_lock);
+	mutex_init(&gsw->flood_lock);
 	
 	rc = rtl837x_mdio_regmap_config;
 	rc.lock_arg = gsw;


### PR DESCRIPTION
## Summary

Extend the RTL8373 DSA bridge-port flag support with the three Linux flood
flags:

- `BR_FLOOD` through the unknown-unicast flood mask;
- `BR_MCAST_FLOOD` through the unknown L2, IPv4 multicast, and IPv6 multicast
  masks;
- `BR_BCAST_FLOOD` through the broadcast flood mask.

The learning, hairpin, isolation, and FDB functionality used by the shared
bridge-flag dispatcher is already in `flint3-be9300`; this PR adds only the
flood-mask operations.

## Implementation

The DSA callback uses the existing RTL8373 RTK/DAL
`rtk_l2_floodPortMask_{get,set}()` operations. It does not access registers
directly. Each update reads the complete logical port mask, changes only the
requested user-port bit, and preserves the CPU and all other port bits.

All required masks are read before any write. A switch-level mutex serializes
updates, and a failed write restores every mask already attempted, including
the failing operation. Unsupported flags return `-EOPNOTSUPP` with the
existing extack message; invalid or non-user ports retain `-EINVAL`.

## Scope

This PR does not change `tag_8021q`, VLAN/PVID, STP, LAG, MDB, or the merged
learning/hairpin/isolation implementations. It does not touch the CPU-port
bit in any flood mask.

## Validation

- Rebased onto current `flint3-be9300` at
  `a655214e41fb8715d87e923e6a31bb1e9c6508ba`.
- Final diff is limited to `rtl837x_common.h`, `rtl837x_dsa_ops.c`, and
  `rtl837x_mdio.c`.
- `git diff --check`: passed.
- `scripts/checkpatch.pl --no-tree --terse`: passed with no new errors or
  warnings.
- OpenWrt package compilation was not completed on this macOS host because
  the repository prerequisite checks require a case-sensitive filesystem and
  GNU host tools.
- No hardware validation was performed.

## Dependencies

The earlier bridge-flag prerequisites (#63, #64, and #65), the FDB mapper
(#71), the link-down/FDB age work (#69), the regression coverage (#70), and
VLAN-specific fast ageing (#72) are already in the base branch. No open code
dependency remains, and this branch contains no duplicate implementation from
those changes.

Hardware review should still exercise each flood flag, preservation of
unrelated mask members including the CPU port, and rollback after an injected
RTK/MDIO failure.
