### PR TITLE
rtl837x: add DSA FDB dump support

### DIFF
--- a/package/kernel/rtl837x/src/rtk-api/dal/rtl8373/dal_rtl8373_lut.c
+++ b/package/kernel/rtl837x/src/rtk-api/dal/rtl8373/dal_rtl8373_lut.c
@@ -206,7 +206,6 @@ static rtk_api_ret_t _rtl8373_getL2LookupTb(rtk_uint32 method, rtl8373_luttb *pL
             retVal = rtl8373_setAsicRegBits(RTL8373_ITA_CTRL0_ADDR, RTL8373_ITA_CTRL0_TBL_ADDR_MASK, pL2Table->address);
             if(retVal != RT_ERR_OK)
                 return retVal;
-            rtlglue_printf("spa is %d\n",pL2Table->spa);
             retVal = rtl8373_setAsicRegBits(RTL8373_ITA_L2_CTRL_ADDR, RTL8373_ITA_L2_CTRL_PORT_NUM_MASK, pL2Table->spa);
             if(retVal != RT_ERR_OK)
                 return retVal;
@@ -215,7 +214,6 @@ static rtk_api_ret_t _rtl8373_getL2LookupTb(rtk_uint32 method, rtl8373_luttb *pL
             retVal = rtl8373_setAsicReg(RTL8373_ITA_CTRL0_ADDR, tblCmd);
             if(retVal != RT_ERR_OK)
                 return retVal;
-            rtlglue_printf("tblcmd is 0x%x\n",tblCmd);
             break;
         default:
             return RT_ERR_INPUT;

--- a/package/kernel/rtl837x/src/rtl837x_dsa_ops.c
+++ b/package/kernel/rtl837x/src/rtl837x_dsa_ops.c
@@ -1929,6 +1929,46 @@ static int rtl837x_port_fdb_del(struct dsa_switch *ds, int port,
 	return rtl837x_to_errno(ret);
 }
 
+static int rtl837x_port_fdb_dump(struct dsa_switch *ds, int port,
+				 dsa_fdb_dump_cb_t *cb, void *data)
+{
+	struct rtk_gsw *gsw = ds->priv;
+	u32 max = RTK_MAX_LUT_ADDRESS;
+	u32 address = 0;
+	int ret;
+
+	if (!rtl837x_valid_port(gsw, port))
+		return -EINVAL;
+
+	while (address < max) {
+		rtk_l2_ucastAddr_t l2 = { 0 };
+		u16 vid;
+
+		ret = rtk_l2_addr_next_get(READMETHOD_NEXT_L2UCSPA, port,
+					   &address, &l2);
+		if (ret == RT_ERR_L2_ENTRY_NOTFOUND ||
+		    ret == RT_ERR_L2_L2UNI_PARAM)
+			break;
+		if (ret != RT_ERR_OK)
+			return rtl837x_to_errno(ret);
+
+		/* tag_8021q VIDs are this driver's own transport, not
+		 * something the bridge configured, so report them as 0 the
+		 * way an unaware entry is reported.
+		 */
+		vid = l2.ivl ? l2.vid_fid : 0;
+		if (vid_is_dsa_8021q(vid))
+			vid = 0;
+
+		ret = cb(l2.mac.octet, vid, l2.is_static, data);
+		if (ret)
+			return ret;
+
+		address++;
+	}
+
+	return 0;
+}
 static const struct dsa_switch_ops rtl837x_dsa_ops = {
 	.get_tag_protocol = rtl837x_get_tag_protocol,
 	.devlink_info_get = rtl837x_devlink_info_get,
@@ -1959,6 +1999,7 @@ static const struct dsa_switch_ops rtl837x_dsa_ops = {
 	.port_vlan_del = rtl837x_port_vlan_del,
 	.port_fdb_add = rtl837x_port_fdb_add,
 	.port_fdb_del = rtl837x_port_fdb_del,
+	.port_fdb_dump = rtl837x_port_fdb_dump,
 	.tag_8021q_vlan_add = rtl837x_tag_8021q_vlan_add,
 	.tag_8021q_vlan_del = rtl837x_tag_8021q_vlan_del,
 };

--- a/package/kernel/rtl837x/src/rtl837x_dsa_ops.c
+++ b/package/kernel/rtl837x/src/rtl837x_dsa_ops.c
@@ -1950,6 +1950,10 @@ static int rtl837x_port_fdb_dump(struct dsa_switch *ds, int port,
 			break;
 		if (ret != RT_ERR_OK)
 			return rtl837x_to_errno(ret);
+		if (l2.port != port || is_multicast_ether_addr(l2.mac.octet)) {
+			address++;
+			continue;
+		}
 
 		/* tag_8021q VIDs are this driver's own transport, not
 		 * something the bridge configured, so report them as 0 the

--- a/package/kernel/rtl837x/src/rtl837x_dsa_ops.c
+++ b/package/kernel/rtl837x/src/rtl837x_dsa_ops.c
@@ -1946,8 +1946,7 @@ static int rtl837x_port_fdb_dump(struct dsa_switch *ds, int port,
 
 		ret = rtk_l2_addr_next_get(READMETHOD_NEXT_L2UCSPA, port,
 					   &address, &l2);
-		if (ret == RT_ERR_L2_ENTRY_NOTFOUND ||
-		    ret == RT_ERR_L2_L2UNI_PARAM)
+		if (ret == RT_ERR_L2_ENTRY_NOTFOUND)
 			break;
 		if (ret != RT_ERR_OK)
 			return rtl837x_to_errno(ret);
@@ -1969,6 +1968,7 @@ static int rtl837x_port_fdb_dump(struct dsa_switch *ds, int port,
 
 	return 0;
 }
+
 static const struct dsa_switch_ops rtl837x_dsa_ops = {
 	.get_tag_protocol = rtl837x_get_tag_protocol,
 	.devlink_info_get = rtl837x_devlink_info_get,


### PR DESCRIPTION
## Summary

Add focused DSA `port_fdb_dump` support for RTL837x so Linux can enumerate
hardware-learned unicast entries for a switch port. This is the independently
reviewable FDB part extracted from #3; MDB and multicast behavior remain out
of scope.

## Implementation

- Add `.port_fdb_dump` using `READMETHOD_NEXT_L2UCSPA`.
- Stop iteration only on `RT_ERR_L2_ENTRY_NOTFOUND`; propagate every other
  SDK/DAL failure through `rtl837x_to_errno()`.
- Skip entries returned for a different source port and multicast MACs before
  invoking the DSA callback.
- Preserve explicit IVL VLAN IDs and report the driver's internal
  `tag_8021q` transport VIDs as Linux VID 0.
- Remove the two unconditional vendor console prints from the
  `NEXT_L2UCSPA` DAL path.
- Propagate callback errors such as `-EMSGSIZE`.

## Integration

The RTL8373 `l2_addr_next_get` mapper is already provided by merged #71 and is
inherited from `flint3-be9300`; this PR does not duplicate that mapper change.
The branch is rebased onto the current `flint3-be9300` tip
`ccf16a0878d1985210618fa7b2f7905427fbd68d`; its new head is
`2de1c6fa3a398a301d73b04703a18290420849b5`.
The final diff contains only the iterator cleanup and DSA dump callback.

## Scope

This PR intentionally does not add MDB add/delete, IGMP/MLD state changes,
multicast lookup-mode changes, multicast CPU membership, flood control, or
LAG-specific FDB handling.

## Validation

- Final diff is limited to
  `package/kernel/rtl837x/src/rtk-api/dal/rtl8373/dal_rtl8373_lut.c` and
  `package/kernel/rtl837x/src/rtl837x_dsa_ops.c`.
- `git diff --check`: passed.
- `scripts/checkpatch.pl --no-tree --terse`: passed with no new errors or
  warnings.
- No OpenWrt package build was completed on this macOS host because the
  repository prerequisite checks require a case-sensitive filesystem and GNU
  host tools.
- No hardware validation was performed.

Suggested hardware checks are dynamic/static FDB reporting, source-port
separation, multicast exclusion, VLAN-aware VID preservation,
`tag_8021q`/VID-0 normalization, callback error propagation, and aged-entry
removal.

The maintainer review follow-up is now in the branch; please re-review the
updated FDB-only implementation. PR #3 remains the separate MDB/reference
work and is not a dependency of this change.


