### PR TITLE
rtl837x: offload bridge port learning flag

### DIFF
--- a/package/kernel/rtl837x/src/rtl837x_dsa_ops.c
+++ b/package/kernel/rtl837x/src/rtl837x_dsa_ops.c
@@ -46,6 +46,43 @@ static u32 rtl837x_user_ports(struct rtk_gsw *gsw)
 	return gsw->valid_port_mask & ~BIT(gsw->cpu_port);
 }
 
+#define RTL837X_SUPPORTED_BRIDGE_FLAGS BR_LEARNING
+
+static int rtl837x_port_pre_bridge_flags(struct dsa_switch *ds, int port,
+					 struct switchdev_brport_flags flags,
+					 struct netlink_ext_ack *extack)
+{
+	struct rtk_gsw *gsw = ds->priv;
+
+	if (!rtl837x_user_port(gsw, port))
+		return -EINVAL;
+
+	if (flags.mask & ~RTL837X_SUPPORTED_BRIDGE_FLAGS) {
+		NL_SET_ERR_MSG_MOD(extack,
+				   "unsupported bridge port flag");
+		return -EOPNOTSUPP;
+	}
+
+	return 0;
+}
+
+static int rtl837x_port_bridge_flags(struct dsa_switch *ds, int port,
+					 struct switchdev_brport_flags flags,
+					 struct netlink_ext_ack *extack)
+{
+	rtk_mac_cnt_t limit;
+	rtk_api_ret_t ret;
+
+	ret = rtl837x_port_pre_bridge_flags(ds, port, flags, extack);
+	if (ret)
+		return ret;
+
+	limit = flags.val & BR_LEARNING ? RTK_MAX_NUM_OF_LEARN_LIMIT : 0;
+	ret = rtk_l2_limitLearningCnt_set(port, limit);
+
+	return rtl837x_to_errno(ret);
+}
+
 static bool rtl837x_support_eee(struct dsa_switch *ds, int port)
 {
 	struct rtk_gsw *gsw = ds->priv;
@@ -1019,6 +1056,8 @@ static const struct dsa_switch_ops rtl837x_dsa_ops = {
 	.get_sset_count = rtl837x_get_sset_count,
 	.get_pause_stats = rtl837x_get_pause_stats,
 	.set_ageing_time = rtl837x_set_ageing_time,
+	.port_pre_bridge_flags = rtl837x_port_pre_bridge_flags,
+	.port_bridge_flags = rtl837x_port_bridge_flags,
 	.support_eee = rtl837x_support_eee,
 	.set_mac_eee = rtl837x_set_mac_eee,
 	.port_bridge_join = dsa_tag_8021q_bridge_join,

--- a/package/kernel/rtl837x/src/rtl837x_dsa_ops.c
+++ b/package/kernel/rtl837x/src/rtl837x_dsa_ops.c
@@ -46,6 +46,20 @@ static u32 rtl837x_user_ports(struct rtk_gsw *gsw)
 	return gsw->valid_port_mask & ~BIT(gsw->cpu_port);
 }
 
+static int rtl837x_set_learning(struct rtk_gsw *gsw, int port, bool enable)
+{
+	rtk_mac_cnt_t limit;
+	rtk_api_ret_t ret;
+
+	if (!rtl837x_user_port(gsw, port))
+		return -EINVAL;
+
+	limit = enable ? RTK_MAX_NUM_OF_LEARN_LIMIT : 0;
+	ret = rtk_l2_limitLearningCnt_set(port, limit);
+
+	return rtl837x_to_errno(ret);
+}
+
 #define RTL837X_SUPPORTED_BRIDGE_FLAGS BR_LEARNING
 
 static int rtl837x_port_pre_bridge_flags(struct dsa_switch *ds, int port,
@@ -70,17 +84,13 @@ static int rtl837x_port_bridge_flags(struct dsa_switch *ds, int port,
 					 struct switchdev_brport_flags flags,
 					 struct netlink_ext_ack *extack)
 {
-	rtk_mac_cnt_t limit;
-	rtk_api_ret_t ret;
+	int ret;
 
 	ret = rtl837x_port_pre_bridge_flags(ds, port, flags, extack);
 	if (ret)
 		return ret;
 
-	limit = flags.val & BR_LEARNING ? RTK_MAX_NUM_OF_LEARN_LIMIT : 0;
-	ret = rtk_l2_limitLearningCnt_set(port, limit);
-
-	return rtl837x_to_errno(ret);
+	return rtl837x_set_learning(ds->priv, port, flags.val & BR_LEARNING);
 }
 
 static bool rtl837x_support_eee(struct dsa_switch *ds, int port)
@@ -409,6 +419,15 @@ static int rtl837x_setup(struct dsa_switch *ds)
 	ret = rtk_l2_init();
 	if (ret)
 		return rtl837x_to_errno(ret);
+
+	for (port = 0; port < RTK_MAX_NUM_OF_PORT; port++) {
+		if (!rtl837x_user_port(gsw, port))
+			continue;
+
+		ret = rtl837x_set_learning(gsw, port, false);
+		if (ret)
+			return ret;
+	}
 
 	ret = rtk_l2_table_clear();
 	if (ret)


### PR DESCRIPTION
## Summary

Offload the Linux `BR_LEARNING` bridge-port flag on RTL8373 user ports.

## Details

- validate the bridge flag mask before touching hardware;
- return `-EOPNOTSUPP` with an extack message for unsupported flags;
- keep `-EINVAL` for an invalid or non-user port;
- map learning on to the RTL8373 maximum per-port learning limit and learning off to zero, which the DAL documents as disabling learning;
- initialize every standalone user port with hardware learning disabled during switch setup, as expected by Linux DSA.

This uses the existing RTK/DAL learning-limit API and does not add support for
`BR_PORT_LOCKED` or any other bridge flag. The implementation preserves the
current STP/port-enable lifecycle from the base branch. It is intentionally the
first bridge-flag layer; later bridge-flag PRs must extend these callbacks
rather than install competing callback implementations.

## Validation

- Rebased onto current `upstream/flint3-be9300` at
  `79d086e797e60c0dfb195d4556a5bf5ad1332fc8`.
- Final diff is limited to BR_LEARNING helper/callback/setup initialization in
  `rtl837x_dsa_ops.c`.
- `git diff --check`: passed.
- `scripts/checkpatch.pl --no-tree --terse`: passed.
- Full `make package/kernel/rtl837x/compile V=s` was not available on the
  current macOS host because the OpenWrt prerequisite check rejects the
  Apple-provided GNU Make 3.81 before package compilation.
- No hardware test was run.
