### PR TITLE
rtl837x: expose hardware port counters through get_stats64

### DIFF
--- a/package/kernel/rtl837x/src/rtl837x_common.h
+++ b/package/kernel/rtl837x/src/rtl837x_common.h
@@ -7,7 +7,9 @@
 #define __RTL8372_COMMON_H__
 
 #include <linux/of_mdio.h>
+#include <linux/netdevice.h>
 #include <linux/regmap.h>
+#include <linux/spinlock.h>
 #include <linux/workqueue.h>
 #include <linux/debugfs.h>
 #include <net/dsa.h>
@@ -54,6 +56,26 @@ struct rtl837x_mib_counter {
 struct rtl837x_sdsmode_map {
 	rtk_sds_mode_t mode;
 	const char *name;
+};
+
+struct rtl837x_mib_snapshot {
+	u64 rx_octets;
+	u64 tx_octets;
+	u64 rx_ucast_pkts;
+	u64 rx_mcast_pkts;
+	u64 rx_bcast_pkts;
+	u64 tx_ucast_pkts;
+	u64 tx_mcast_pkts;
+	u64 tx_bcast_pkts;
+	u32 tx_discards;
+	u32 collisions;
+};
+
+struct rtl837x_port_stats {
+	spinlock_t lock;
+	struct rtnl_link_stats64 stats;
+	struct rtl837x_mib_snapshot snapshot;
+	bool snapshot_valid;
 };
 
 typedef struct rtl837x_pnswap_cfg_s {
@@ -129,6 +151,9 @@ struct rtk_gsw {
 
 	int default_work_delay_ms;
 	struct delayed_work status_check_work;
+	struct delayed_work stats_work;
+	struct rtl837x_port_stats port_stats[RTK_MAX_NUM_OF_PORT];
+	bool stats_work_stopping;
 };
 
 extern int rtl8372n_hw_init(struct rtk_gsw *gsw, rtl837x_pnswap_cfg_t swap_cfg);

--- a/package/kernel/rtl837x/src/rtl837x_common.h
+++ b/package/kernel/rtl837x/src/rtl837x_common.h
@@ -67,8 +67,8 @@ struct rtl837x_mib_snapshot {
 	u64 tx_ucast_pkts;
 	u64 tx_mcast_pkts;
 	u64 tx_bcast_pkts;
-	u32 tx_discards;
-	u32 collisions;
+	u32 tx_discards; /* RTL8373 ifOutDiscards is 32-bit. */
+	u32 collisions; /* RTL8373 tx_etherStatsCollisions is 32-bit. */
 };
 
 struct rtl837x_port_stats {

--- a/package/kernel/rtl837x/src/rtl837x_dsa_ops.c
+++ b/package/kernel/rtl837x/src/rtl837x_dsa_ops.c
@@ -258,6 +258,208 @@ static u64 rtl837x_read_stat(int port, u32 counter)
 	return value;
 }
 
+static int rtl837x_read_stat_value(int port, rtk_stat_port_type_t counter,
+				   u64 *value)
+{
+	rtk_stat_counter_t counter_value = 0;
+	int ret;
+
+	ret = rtk_stat_port_get(port, counter, &counter_value);
+	if (ret)
+		return rtl837x_to_errno(ret);
+
+	*value = counter_value;
+	return 0;
+}
+
+static int rtl837x_read_stats_snapshot(int port,
+				       struct rtl837x_mib_snapshot *snapshot)
+{
+	u64 value;
+	int ret;
+
+	ret = rtl837x_read_stat_value(port, ifInOctets, &value);
+	if (ret)
+		return ret;
+	snapshot->rx_octets = value;
+
+	ret = rtl837x_read_stat_value(port, ifOutOctets, &value);
+	if (ret)
+		return ret;
+	snapshot->tx_octets = value;
+
+	ret = rtl837x_read_stat_value(port, ifInUcastPkts, &value);
+	if (ret)
+		return ret;
+	snapshot->rx_ucast_pkts = value;
+
+	ret = rtl837x_read_stat_value(port, ifInMulticastPkts, &value);
+	if (ret)
+		return ret;
+	snapshot->rx_mcast_pkts = value;
+
+	ret = rtl837x_read_stat_value(port, ifInBroadcastPkts, &value);
+	if (ret)
+		return ret;
+	snapshot->rx_bcast_pkts = value;
+
+	ret = rtl837x_read_stat_value(port, ifOutUcastPkts, &value);
+	if (ret)
+		return ret;
+	snapshot->tx_ucast_pkts = value;
+
+	ret = rtl837x_read_stat_value(port, ifOutMulticastPkts, &value);
+	if (ret)
+		return ret;
+	snapshot->tx_mcast_pkts = value;
+
+	ret = rtl837x_read_stat_value(port, ifOutBroadcastPkts, &value);
+	if (ret)
+		return ret;
+	snapshot->tx_bcast_pkts = value;
+
+	ret = rtl837x_read_stat_value(port, ifOutDiscards, &value);
+	if (ret)
+		return ret;
+	snapshot->tx_discards = value;
+
+	ret = rtl837x_read_stat_value(port, tx_etherStatsCollisions, &value);
+	if (ret)
+		return ret;
+	snapshot->collisions = value;
+
+	return 0;
+}
+
+static bool
+rtl837x_stats_reset_detected(const struct rtl837x_mib_snapshot *old,
+				      const struct rtl837x_mib_snapshot *current)
+{
+	return current->rx_octets < old->rx_octets ||
+	       current->tx_octets < old->tx_octets ||
+	       current->rx_ucast_pkts < old->rx_ucast_pkts ||
+	       current->rx_mcast_pkts < old->rx_mcast_pkts ||
+	       current->rx_bcast_pkts < old->rx_bcast_pkts ||
+	       current->tx_ucast_pkts < old->tx_ucast_pkts ||
+	       current->tx_mcast_pkts < old->tx_mcast_pkts ||
+	       current->tx_bcast_pkts < old->tx_bcast_pkts ||
+	       current->tx_discards < old->tx_discards ||
+	       current->collisions < old->collisions;
+}
+
+static void rtl837x_update_port_stats(struct rtk_gsw *gsw, int port,
+				       const struct rtl837x_mib_snapshot *snapshot)
+{
+	struct rtl837x_port_stats *port_stats = &gsw->port_stats[port];
+	const struct rtl837x_mib_snapshot *old = &port_stats->snapshot;
+
+	spin_lock_bh(&port_stats->lock);
+
+	if (!port_stats->snapshot_valid ||
+	    rtl837x_stats_reset_detected(old, snapshot)) {
+		if (port_stats->snapshot_valid)
+			memset(&port_stats->stats, 0, sizeof(port_stats->stats));
+		port_stats->snapshot = *snapshot;
+		port_stats->snapshot_valid = true;
+		spin_unlock_bh(&port_stats->lock);
+		return;
+	}
+
+	port_stats->stats.rx_bytes += snapshot->rx_octets - old->rx_octets;
+	port_stats->stats.tx_bytes += snapshot->tx_octets - old->tx_octets;
+	port_stats->stats.rx_packets +=
+		snapshot->rx_ucast_pkts - old->rx_ucast_pkts +
+		snapshot->rx_mcast_pkts - old->rx_mcast_pkts +
+		snapshot->rx_bcast_pkts - old->rx_bcast_pkts;
+	port_stats->stats.tx_packets +=
+		snapshot->tx_ucast_pkts - old->tx_ucast_pkts +
+		snapshot->tx_mcast_pkts - old->tx_mcast_pkts +
+		snapshot->tx_bcast_pkts - old->tx_bcast_pkts;
+	port_stats->stats.tx_dropped +=
+		(u32)(snapshot->tx_discards - old->tx_discards);
+	port_stats->stats.multicast +=
+		snapshot->rx_mcast_pkts - old->rx_mcast_pkts;
+	port_stats->stats.collisions +=
+		(u32)(snapshot->collisions - old->collisions);
+
+	port_stats->snapshot = *snapshot;
+	spin_unlock_bh(&port_stats->lock);
+}
+
+/*
+ * dal_rtl8373_portMib_read() exposes the ifIn/ifOut octet and packet
+ * counters as 64-bit values.  The discard and collision counters below are
+ * 32-bit, so one second leaves ample margin before they can wrap even at the
+ * RTL8373 line rate.
+ */
+#define RTL837X_STATS_POLL_INTERVAL (HZ)
+
+static void rtl837x_stats_work_func(struct work_struct *work)
+{
+	struct rtk_gsw *gsw = container_of(to_delayed_work(work),
+					 struct rtk_gsw, stats_work);
+	struct rtl837x_mib_snapshot snapshot;
+	unsigned long user_ports = rtl837x_user_ports(gsw);
+	int port, ret;
+
+	for_each_set_bit(port, &user_ports, RTK_MAX_NUM_OF_PORT) {
+		if (READ_ONCE(gsw->stats_work_stopping))
+			return;
+
+		ret = rtl837x_read_stats_snapshot(port, &snapshot);
+		if (ret) {
+			dev_warn_ratelimited(gsw->dev,
+					     "failed to read statistics for port %d: %d\n",
+					     port, ret);
+			continue;
+		}
+
+		rtl837x_update_port_stats(gsw, port, &snapshot);
+	}
+
+	if (!READ_ONCE(gsw->stats_work_stopping))
+		queue_delayed_work(system_wq, &gsw->stats_work,
+				   RTL837X_STATS_POLL_INTERVAL);
+}
+
+static void rtl837x_stats_init(struct rtk_gsw *gsw)
+{
+	int port;
+
+	for (port = 0; port < RTK_MAX_NUM_OF_PORT; port++)
+		spin_lock_init(&gsw->port_stats[port].lock);
+
+	INIT_DELAYED_WORK(&gsw->stats_work, rtl837x_stats_work_func);
+	WRITE_ONCE(gsw->stats_work_stopping, true);
+}
+
+static void rtl837x_stats_start(struct rtk_gsw *gsw)
+{
+	struct rtl837x_port_stats *port_stats;
+	int port;
+
+	for (port = 0; port < RTK_MAX_NUM_OF_PORT; port++) {
+		port_stats = &gsw->port_stats[port];
+
+		spin_lock_bh(&port_stats->lock);
+		/* Establish a post-registration baseline; do not count earlier traffic. */
+		memset(&port_stats->stats, 0, sizeof(port_stats->stats));
+		memset(&port_stats->snapshot, 0, sizeof(port_stats->snapshot));
+		port_stats->snapshot_valid = false;
+		spin_unlock_bh(&port_stats->lock);
+	}
+
+	WRITE_ONCE(gsw->stats_work_stopping, false);
+	queue_delayed_work(system_wq, &gsw->stats_work,
+			   RTL837X_STATS_POLL_INTERVAL);
+}
+
+static void rtl837x_stats_stop(struct rtk_gsw *gsw)
+{
+	WRITE_ONCE(gsw->stats_work_stopping, true);
+	cancel_delayed_work_sync(&gsw->stats_work);
+}
+
 static int rtl837x_write_vlan(struct rtk_gsw *gsw, u16 vid)
 {
 	rtk_vlan_entry_t vlan = { 0 };
@@ -509,12 +711,17 @@ static int rtl837x_setup(struct dsa_switch *ds)
 		return ret;
 	}
 
+	rtl837x_stats_start(gsw);
+
 	return 0;
 }
 
 static void rtl837x_teardown(struct dsa_switch *ds)
 {
+	struct rtk_gsw *gsw = ds->priv;
 	int ret;
+
+	rtl837x_stats_stop(gsw);
 
 	rtnl_lock();
 	dsa_tag_8021q_unregister(ds);
@@ -967,6 +1174,21 @@ static void rtl837x_get_rmon_stats(struct dsa_switch *ds, int port,
 	 */
 }
 
+static void rtl837x_get_stats64(struct dsa_switch *ds, int port,
+				struct rtnl_link_stats64 *stats)
+{
+	struct rtk_gsw *gsw = ds->priv;
+	struct rtl837x_port_stats *port_stats;
+
+	if (!rtl837x_user_port(gsw, port))
+		return;
+
+	port_stats = &gsw->port_stats[port];
+	spin_lock_bh(&port_stats->lock);
+	*stats = port_stats->stats;
+	spin_unlock_bh(&port_stats->lock);
+}
+
 static int rtl837x_set_ageing_time(struct dsa_switch *ds, unsigned int msecs)
 {
 	unsigned int secs = DIV_ROUND_UP(msecs, 1000);
@@ -1245,6 +1467,7 @@ static const struct dsa_switch_ops rtl837x_dsa_ops = {
 	.get_strings = rtl837x_get_strings,
 	.get_ethtool_stats = rtl837x_get_ethtool_stats,
 	.get_sset_count = rtl837x_get_sset_count,
+	.get_stats64 = rtl837x_get_stats64,
 	.get_pause_stats = rtl837x_get_pause_stats,
 	.get_eth_phy_stats = rtl837x_get_eth_phy_stats,
 	.get_eth_mac_stats = rtl837x_get_eth_mac_stats,
@@ -1272,6 +1495,8 @@ int rtl837x_dsa_register(struct rtk_gsw *gsw)
 {
 	struct dsa_switch *ds = &gsw->ds;
 	int ret;
+
+	rtl837x_stats_init(gsw);
 
 	ds->dev = gsw->dev;
 	ds->priv = gsw;
@@ -1307,6 +1532,7 @@ void rtl837x_dsa_shutdown(struct rtk_gsw *gsw)
 	if (!gsw->dsa_registered)
 		return;
 
+	rtl837x_stats_stop(gsw);
 	dsa_switch_shutdown(&gsw->ds);
 	gsw->dsa_registered = false;
 }

--- a/package/kernel/rtl837x/src/rtl837x_dsa_ops.c
+++ b/package/kernel/rtl837x/src/rtl837x_dsa_ops.c
@@ -278,42 +278,42 @@ static int rtl837x_read_stats_snapshot(int port,
 	u64 value;
 	int ret;
 
-	ret = rtl837x_read_stat_value(port, ifInOctets, &value);
+	ret = rtl837x_read_stat_value(port, ifInOctets_H, &value);
 	if (ret)
 		return ret;
 	snapshot->rx_octets = value;
 
-	ret = rtl837x_read_stat_value(port, ifOutOctets, &value);
+	ret = rtl837x_read_stat_value(port, ifOutOctets_H, &value);
 	if (ret)
 		return ret;
 	snapshot->tx_octets = value;
 
-	ret = rtl837x_read_stat_value(port, ifInUcastPkts, &value);
+	ret = rtl837x_read_stat_value(port, ifInUcastPkts_H, &value);
 	if (ret)
 		return ret;
 	snapshot->rx_ucast_pkts = value;
 
-	ret = rtl837x_read_stat_value(port, ifInMulticastPkts, &value);
+	ret = rtl837x_read_stat_value(port, ifInMulticastPkts_H, &value);
 	if (ret)
 		return ret;
 	snapshot->rx_mcast_pkts = value;
 
-	ret = rtl837x_read_stat_value(port, ifInBroadcastPkts, &value);
+	ret = rtl837x_read_stat_value(port, ifInBroadcastPkts_H, &value);
 	if (ret)
 		return ret;
 	snapshot->rx_bcast_pkts = value;
 
-	ret = rtl837x_read_stat_value(port, ifOutUcastPkts, &value);
+	ret = rtl837x_read_stat_value(port, ifOutUcastPkts_H, &value);
 	if (ret)
 		return ret;
 	snapshot->tx_ucast_pkts = value;
 
-	ret = rtl837x_read_stat_value(port, ifOutMulticastPkts, &value);
+	ret = rtl837x_read_stat_value(port, ifOutMulticastPkts_H, &value);
 	if (ret)
 		return ret;
 	snapshot->tx_mcast_pkts = value;
 
-	ret = rtl837x_read_stat_value(port, ifOutBroadcastPkts, &value);
+	ret = rtl837x_read_stat_value(port, ifOutBroadcastPkts_H, &value);
 	if (ret)
 		return ret;
 	snapshot->tx_bcast_pkts = value;

--- a/package/kernel/rtl837x/src/rtl837x_dsa_ops.c
+++ b/package/kernel/rtl837x/src/rtl837x_dsa_ops.c
@@ -258,72 +258,58 @@ static u64 rtl837x_read_stat(int port, u32 counter)
 	return value;
 }
 
-static int rtl837x_read_stat_value(int port, rtk_stat_port_type_t counter,
-				   u64 *value)
-{
-	rtk_stat_counter_t counter_value = 0;
-	int ret;
-
-	ret = rtk_stat_port_get(port, counter, &counter_value);
-	if (ret)
-		return rtl837x_to_errno(ret);
-
-	*value = counter_value;
-	return 0;
-}
-
 static int rtl837x_read_stats_snapshot(int port,
-				       struct rtl837x_mib_snapshot *snapshot)
+					       struct rtl837x_mib_snapshot *snapshot)
 {
 	u64 value;
 	int ret;
 
-	ret = rtl837x_read_stat_value(port, ifInOctets_H, &value);
+	ret = rtl837x_read_ethtool_stat(port, ifInOctets_H, &value);
 	if (ret)
 		return ret;
 	snapshot->rx_octets = value;
 
-	ret = rtl837x_read_stat_value(port, ifOutOctets_H, &value);
+	ret = rtl837x_read_ethtool_stat(port, ifOutOctets_H, &value);
 	if (ret)
 		return ret;
 	snapshot->tx_octets = value;
 
-	ret = rtl837x_read_stat_value(port, ifInUcastPkts_H, &value);
+	ret = rtl837x_read_ethtool_stat(port, ifInUcastPkts_H, &value);
 	if (ret)
 		return ret;
 	snapshot->rx_ucast_pkts = value;
 
-	ret = rtl837x_read_stat_value(port, ifInMulticastPkts_H, &value);
+	ret = rtl837x_read_ethtool_stat(port, ifInMulticastPkts_H, &value);
 	if (ret)
 		return ret;
 	snapshot->rx_mcast_pkts = value;
 
-	ret = rtl837x_read_stat_value(port, ifInBroadcastPkts_H, &value);
+	ret = rtl837x_read_ethtool_stat(port, ifInBroadcastPkts_H, &value);
 	if (ret)
 		return ret;
 	snapshot->rx_bcast_pkts = value;
 
-	ret = rtl837x_read_stat_value(port, ifOutUcastPkts_H, &value);
+	ret = rtl837x_read_ethtool_stat(port, ifOutUcastPkts_H, &value);
 	if (ret)
 		return ret;
 	snapshot->tx_ucast_pkts = value;
 
-	ret = rtl837x_read_stat_value(port, ifOutMulticastPkts_H, &value);
+	ret = rtl837x_read_ethtool_stat(port, ifOutMulticastPkts_H, &value);
 	if (ret)
 		return ret;
 	snapshot->tx_mcast_pkts = value;
 
-	ret = rtl837x_read_stat_value(port, ifOutBroadcastPkts_H, &value);
+	ret = rtl837x_read_ethtool_stat(port, ifOutBroadcastPkts_H, &value);
 	if (ret)
 		return ret;
 	snapshot->tx_bcast_pkts = value;
 
-	ret = rtl837x_read_stat_value(port, ifOutDiscards, &value);
+	ret = rtl837x_read_ethtool_stat(port, ifOutDiscards, &value);
 	if (ret)
 		return ret;
 	snapshot->tx_discards = value;
 
-	ret = rtl837x_read_stat_value(port, tx_etherStatsCollisions, &value);
+	ret = rtl837x_read_ethtool_stat(port, tx_etherStatsCollisions, &value);
 	if (ret)
 		return ret;
 	snapshot->collisions = value;
@@ -332,19 +318,17 @@ static int rtl837x_read_stats_snapshot(int port,
 }
 
 static bool
-rtl837x_stats_reset_detected(const struct rtl837x_mib_snapshot *old,
-				      const struct rtl837x_mib_snapshot *current)
+rtl837x_stats_64bit_reset_detected(const struct rtl837x_mib_snapshot *old,
+						   const struct rtl837x_mib_snapshot *latest)
 {
-	return current->rx_octets < old->rx_octets ||
-	       current->tx_octets < old->tx_octets ||
-	       current->rx_ucast_pkts < old->rx_ucast_pkts ||
-	       current->rx_mcast_pkts < old->rx_mcast_pkts ||
-	       current->rx_bcast_pkts < old->rx_bcast_pkts ||
-	       current->tx_ucast_pkts < old->tx_ucast_pkts ||
-	       current->tx_mcast_pkts < old->tx_mcast_pkts ||
-	       current->tx_bcast_pkts < old->tx_bcast_pkts ||
-	       current->tx_discards < old->tx_discards ||
-	       current->collisions < old->collisions;
+	return latest->rx_octets < old->rx_octets ||
+	       latest->tx_octets < old->tx_octets ||
+	       latest->rx_ucast_pkts < old->rx_ucast_pkts ||
+	       latest->rx_mcast_pkts < old->rx_mcast_pkts ||
+	       latest->rx_bcast_pkts < old->rx_bcast_pkts ||
+	       latest->tx_ucast_pkts < old->tx_ucast_pkts ||
+	       latest->tx_mcast_pkts < old->tx_mcast_pkts ||
+	       latest->tx_bcast_pkts < old->tx_bcast_pkts;
 }
 
 static void rtl837x_update_port_stats(struct rtk_gsw *gsw, int port,
@@ -352,18 +336,29 @@ static void rtl837x_update_port_stats(struct rtk_gsw *gsw, int port,
 {
 	struct rtl837x_port_stats *port_stats = &gsw->port_stats[port];
 	const struct rtl837x_mib_snapshot *old = &port_stats->snapshot;
+	u32 tx_discards_delta;
+	u32 collisions_delta;
 
 	spin_lock_bh(&port_stats->lock);
 
 	if (!port_stats->snapshot_valid ||
-	    rtl837x_stats_reset_detected(old, snapshot)) {
-		if (port_stats->snapshot_valid)
-			memset(&port_stats->stats, 0, sizeof(port_stats->stats));
+	    rtl837x_stats_64bit_reset_detected(old, snapshot)) {
+		/* A backwards 64-bit counter means the hardware MIB was reset.
+		 * Keep Linux counters monotonic and use this sample only as the
+		 * new hardware baseline.
+		 */
 		port_stats->snapshot = *snapshot;
 		port_stats->snapshot_valid = true;
 		spin_unlock_bh(&port_stats->lock);
 		return;
 	}
+
+	/* These hardware counters are 32-bit.  Unsigned subtraction is
+	 * intentionally modulo-2^32, so an ordinary wrap is accumulated as
+	 * its real delta instead of being mistaken for a reset.
+	 */
+	tx_discards_delta = snapshot->tx_discards - old->tx_discards;
+	collisions_delta = snapshot->collisions - old->collisions;
 
 	port_stats->stats.rx_bytes += snapshot->rx_octets - old->rx_octets;
 	port_stats->stats.tx_bytes += snapshot->tx_octets - old->tx_octets;
@@ -375,12 +370,10 @@ static void rtl837x_update_port_stats(struct rtk_gsw *gsw, int port,
 		snapshot->tx_ucast_pkts - old->tx_ucast_pkts +
 		snapshot->tx_mcast_pkts - old->tx_mcast_pkts +
 		snapshot->tx_bcast_pkts - old->tx_bcast_pkts;
-	port_stats->stats.tx_dropped +=
-		(u32)(snapshot->tx_discards - old->tx_discards);
+	port_stats->stats.tx_dropped += tx_discards_delta;
 	port_stats->stats.multicast +=
 		snapshot->rx_mcast_pkts - old->rx_mcast_pkts;
-	port_stats->stats.collisions +=
-		(u32)(snapshot->collisions - old->collisions);
+	port_stats->stats.collisions += collisions_delta;
 
 	port_stats->snapshot = *snapshot;
 	spin_unlock_bh(&port_stats->lock);


### PR DESCRIPTION
## Summary

Expose RTL8373 hardware port counters through DSA `get_stats64` without reading the switch from the network statistics callback.

## Details

- poll the hardware counters once per second after DSA/tag registration;
- cache the resulting `rtnl_link_stats64` values behind a per-port spinlock;
- combine the RTL8373 64-bit packet/octet counters and 32-bit discard/collision counters into standard link statistics;
- detect counter resets before accumulating deltas;
- stop and synchronously drain the delayed work during teardown and shutdown.

The 64-bit octet and packet counters are the reset indicators. A backwards
64-bit value establishes a new hardware baseline but never clears accumulated
Linux `rtnl_link_stats64`. The known 32-bit discard and collision counters use
unsigned modulo-2^32 deltas, so an ordinary wrap is counted instead of being
mistaken for a reset. A failed hardware read leaves both the previous snapshot
and the accumulated statistics untouched for the next poll.

The implementation uses the existing RTK/DAL MIB API; it does not add raw register accesses to the DSA callbacks.

PR #67 is now merged into `flint3-be9300` and is inherited by this branch. The
final PR diff contains only the cached `get_stats64` implementation and its
per-device statistics state; it does not duplicate the structured ethtool
callbacks from #67.

## Validation

- Rebased onto current `upstream/flint3-be9300` at
  `9b5702112eead22aa4f5b69001db67e411eea15c`.
- Final diff is limited to the cached `get_stats64` implementation and its
  per-device statistics state.
- `git diff --check`: passed.
- `scripts/checkpatch.pl --no-tree --terse`: passed.
- Corrected the counter references to the RTL8373 API's paired `_H` MIB identifiers.
- Verified that the reset path is baseline-only and that 32-bit counters use
  modulo subtraction without resetting userspace-visible statistics.
- Full `make package/kernel/rtl837x/compile V=s` was not available on the
  current macOS host because the OpenWrt prerequisite check rejects the
  Apple-provided GNU Make 3.81 before package compilation.
- No hardware test was run.
