### PR TITLE
rtl837x: expose standard ethtool MAC and RMON statistics

### DIFF
--- a/package/kernel/rtl837x/src/rtl837x_dsa_ops.c
+++ b/package/kernel/rtl837x/src/rtl837x_dsa_ops.c
@@ -179,11 +179,25 @@ static int rtl837x_set_stp_state(struct rtk_gsw *gsw, int port, u8 state)
 	return rtl837x_to_errno(ret);
 }
 
+static int rtl837x_read_stat_value(int port, rtk_stat_port_type_t counter,
+				   u64 *value)
+{
+	rtk_stat_counter_t counter_value = 0;
+	int ret;
+
+	ret = rtk_stat_port_get(port, counter, &counter_value);
+	if (ret)
+		return rtl837x_to_errno(ret);
+
+	*value = counter_value;
+	return 0;
+}
+
 static u64 rtl837x_read_stat(int port, u32 counter)
 {
-	rtk_stat_counter_t value = 0;
+	u64 value;
 
-	if (rtk_stat_port_get(port, counter, &value))
+	if (rtl837x_read_stat_value(port, counter, &value))
 		return 0;
 
 	return value;
@@ -733,6 +747,151 @@ static void rtl837x_get_pause_stats(struct dsa_switch *ds, int port,
 	pause_stats->tx_pause_frames = rtl837x_read_stat(port, dot3OutPauseFrames);
 }
 
+/*
+ * RTL8373 exposes the standard packet categories as full-width counters.
+ * Read the category counters together so a failed read cannot produce a
+ * partial aggregate.
+ */
+static void rtl837x_get_eth_mac_stats(struct dsa_switch *ds, int port,
+					      struct ethtool_eth_mac_stats *mac_stats)
+{
+	struct rtk_gsw *gsw = ds->priv;
+	u64 rx_ucast, rx_mcast, rx_bcast;
+	u64 tx_ucast, tx_mcast, tx_bcast;
+	u64 value;
+
+	if (!rtl837x_valid_port(gsw, port))
+		return;
+
+	if (rtl837x_read_stat_value(port, ifInUcastPkts, &rx_ucast) ||
+	    rtl837x_read_stat_value(port, ifInMulticastPkts, &rx_mcast) ||
+	    rtl837x_read_stat_value(port, ifInBroadcastPkts, &rx_bcast) ||
+	    rtl837x_read_stat_value(port, ifOutUcastPkts, &tx_ucast) ||
+	    rtl837x_read_stat_value(port, ifOutMulticastPkts, &tx_mcast) ||
+	    rtl837x_read_stat_value(port, ifOutBroadcastPkts, &tx_bcast))
+		return;
+
+	mac_stats->FramesReceivedOK = rx_ucast + rx_mcast + rx_bcast;
+	mac_stats->FramesTransmittedOK = tx_ucast + tx_mcast + tx_bcast;
+	mac_stats->MulticastFramesReceivedOK = rx_mcast;
+	mac_stats->BroadcastFramesReceivedOK = rx_bcast;
+	mac_stats->MulticastFramesXmittedOK = tx_mcast;
+	mac_stats->BroadcastFramesXmittedOK = tx_bcast;
+
+	if (!rtl837x_read_stat_value(port, ifInOctets, &value))
+		mac_stats->OctetsReceivedOK = value;
+	if (!rtl837x_read_stat_value(port, ifOutOctets, &value))
+		mac_stats->OctetsTransmittedOK = value;
+	if (!rtl837x_read_stat_value(port, dot3StatsSingleCollisionFrames,
+					     &value))
+		mac_stats->SingleCollisionFrames = value;
+	if (!rtl837x_read_stat_value(port, dot3StatMultipleCollisionFrames,
+					     &value))
+		mac_stats->MultipleCollisionFrames = value;
+	if (!rtl837x_read_stat_value(port, dot3sDeferredTransmissions, &value))
+		mac_stats->FramesWithDeferredXmissions = value;
+	if (!rtl837x_read_stat_value(port, dot3StatsLateCollisions, &value))
+		mac_stats->LateCollisions = value;
+	if (!rtl837x_read_stat_value(port, dot3StatsExcessiveCollisions,
+					     &value))
+		mac_stats->FramesAbortedDueToXSColls = value;
+
+	/*
+	 * rx_etherStatsCRCAlignErrors combines FCS and alignment errors, while
+	 * the standard interface exposes them separately.  Leave both fields
+	 * unset instead of reporting the same combined counter twice.
+	 */
+}
+
+static void rtl837x_get_eth_ctrl_stats(struct dsa_switch *ds, int port,
+					      struct ethtool_eth_ctrl_stats *ctrl_stats)
+{
+	struct rtk_gsw *gsw = ds->priv;
+	u64 value;
+
+	if (!rtl837x_valid_port(gsw, port))
+		return;
+
+	if (!rtl837x_read_stat_value(port, dot3ControlInUnknownOpcodes, &value))
+		ctrl_stats->UnsupportedOpcodesReceived = value;
+
+	/* Pause frames are already exposed through get_pause_stats(). */
+}
+
+static const struct ethtool_rmon_hist_range rtl837x_rmon_ranges[] = {
+	{ 0, 64 },
+	{ 65, 127 },
+	{ 128, 255 },
+	{ 256, 511 },
+	{ 512, 1023 },
+	{ 1024, 1518 },
+	{}
+};
+
+static void rtl837x_get_rmon_stats(struct dsa_switch *ds, int port,
+					      struct ethtool_rmon_stats *rmon_stats,
+					      const struct ethtool_rmon_hist_range **ranges)
+{
+	struct rtk_gsw *gsw = ds->priv;
+	u64 value;
+
+	*ranges = rtl837x_rmon_ranges;
+
+	if (!rtl837x_valid_port(gsw, port))
+		return;
+
+	if (!rtl837x_read_stat_value(port, rx_etherStatsUndersizePkts, &value))
+		rmon_stats->undersize_pkts = value;
+	if (!rtl837x_read_stat_value(port, rx_etherStatsOversizePkts, &value))
+		rmon_stats->oversize_pkts = value;
+	if (!rtl837x_read_stat_value(port, rx_etherStatsFragments, &value))
+		rmon_stats->fragments = value;
+	if (!rtl837x_read_stat_value(port, rx_etherStatsJabbers, &value))
+		rmon_stats->jabbers = value;
+
+	if (!rtl837x_read_stat_value(port, rx_etherStatsPkts64Octets, &value))
+		rmon_stats->hist[0] = value;
+	if (!rtl837x_read_stat_value(port, rx_etherStatsPkts65to127Octets,
+					    &value))
+		rmon_stats->hist[1] = value;
+	if (!rtl837x_read_stat_value(port, rx_etherStatsPkts128to255Octets,
+					    &value))
+		rmon_stats->hist[2] = value;
+	if (!rtl837x_read_stat_value(port, rx_etherStatsPkts256to511Octets,
+					    &value))
+		rmon_stats->hist[3] = value;
+	if (!rtl837x_read_stat_value(port, rx_etherStatsPkts512to1023Octets,
+					    &value))
+		rmon_stats->hist[4] = value;
+	if (!rtl837x_read_stat_value(port, rx_etherStatsPkts1024to1518Octets,
+					    &value))
+		rmon_stats->hist[5] = value;
+
+	if (!rtl837x_read_stat_value(port, tx_etherStatsPkts64Octets, &value))
+		rmon_stats->hist_tx[0] = value;
+	if (!rtl837x_read_stat_value(port, tx_etherStatsPkts65to127Octets,
+					    &value))
+		rmon_stats->hist_tx[1] = value;
+	if (!rtl837x_read_stat_value(port, tx_etherStatsPkts128to255Octets,
+					    &value))
+		rmon_stats->hist_tx[2] = value;
+	if (!rtl837x_read_stat_value(port, tx_etherStatsPkts256to511Octets,
+					    &value))
+		rmon_stats->hist_tx[3] = value;
+	if (!rtl837x_read_stat_value(port, tx_etherStatsPkts512to1023Octets,
+					    &value))
+		rmon_stats->hist_tx[4] = value;
+	if (!rtl837x_read_stat_value(port, tx_etherStatsPkts1024to1518Octets,
+					    &value))
+		rmon_stats->hist_tx[5] = value;
+
+	/*
+	 * The SDK has 1519-to-max counters too, but does not expose the
+	 * RTL8373 maximum frame size needed to describe that range.  Keep the
+	 * seventh bucket unset rather than publishing an invented upper bound.
+	 */
+}
+
 static int rtl837x_set_ageing_time(struct dsa_switch *ds, unsigned int msecs)
 {
 	unsigned int secs = DIV_ROUND_UP(msecs, 1000);
@@ -995,6 +1154,9 @@ static const struct dsa_switch_ops rtl837x_dsa_ops = {
 	.get_ethtool_stats = rtl837x_get_ethtool_stats,
 	.get_sset_count = rtl837x_get_sset_count,
 	.get_pause_stats = rtl837x_get_pause_stats,
+	.get_eth_mac_stats = rtl837x_get_eth_mac_stats,
+	.get_eth_ctrl_stats = rtl837x_get_eth_ctrl_stats,
+	.get_rmon_stats = rtl837x_get_rmon_stats,
 	.set_ageing_time = rtl837x_set_ageing_time,
 	.port_enable = rtl837x_port_enable,
 	.port_disable = rtl837x_port_disable,

--- a/package/kernel/rtl837x/src/rtl837x_dsa_ops.c
+++ b/package/kernel/rtl837x/src/rtl837x_dsa_ops.c
@@ -179,8 +179,8 @@ static int rtl837x_set_stp_state(struct rtk_gsw *gsw, int port, u8 state)
 	return rtl837x_to_errno(ret);
 }
 
-static int rtl837x_read_stat_value(int port, rtk_stat_port_type_t counter,
-				   u64 *value)
+static int rtl837x_read_ethtool_stat(int port, rtk_stat_port_type_t counter,
+					     u64 *value)
 {
 	rtk_stat_counter_t counter_value = 0;
 	int ret;
@@ -197,7 +197,7 @@ static u64 rtl837x_read_stat(int port, u32 counter)
 {
 	u64 value;
 
-	if (rtl837x_read_stat_value(port, counter, &value))
+	if (rtl837x_read_ethtool_stat(port, counter, &value))
 		return 0;
 
 	return value;
@@ -763,12 +763,12 @@ static void rtl837x_get_eth_mac_stats(struct dsa_switch *ds, int port,
 	if (!rtl837x_valid_port(gsw, port))
 		return;
 
-	if (rtl837x_read_stat_value(port, ifInUcastPkts, &rx_ucast) ||
-	    rtl837x_read_stat_value(port, ifInMulticastPkts, &rx_mcast) ||
-	    rtl837x_read_stat_value(port, ifInBroadcastPkts, &rx_bcast) ||
-	    rtl837x_read_stat_value(port, ifOutUcastPkts, &tx_ucast) ||
-	    rtl837x_read_stat_value(port, ifOutMulticastPkts, &tx_mcast) ||
-	    rtl837x_read_stat_value(port, ifOutBroadcastPkts, &tx_bcast))
+	if (rtl837x_read_ethtool_stat(port, ifInUcastPkts_H, &rx_ucast) ||
+	    rtl837x_read_ethtool_stat(port, ifInMulticastPkts_H, &rx_mcast) ||
+	    rtl837x_read_ethtool_stat(port, ifInBroadcastPkts_H, &rx_bcast) ||
+	    rtl837x_read_ethtool_stat(port, ifOutUcastPkts_H, &tx_ucast) ||
+	    rtl837x_read_ethtool_stat(port, ifOutMulticastPkts_H, &tx_mcast) ||
+	    rtl837x_read_ethtool_stat(port, ifOutBroadcastPkts_H, &tx_bcast))
 		return;
 
 	mac_stats->FramesReceivedOK = rx_ucast + rx_mcast + rx_bcast;
@@ -778,21 +778,21 @@ static void rtl837x_get_eth_mac_stats(struct dsa_switch *ds, int port,
 	mac_stats->MulticastFramesXmittedOK = tx_mcast;
 	mac_stats->BroadcastFramesXmittedOK = tx_bcast;
 
-	if (!rtl837x_read_stat_value(port, ifInOctets, &value))
+	if (!rtl837x_read_ethtool_stat(port, ifInOctets_H, &value))
 		mac_stats->OctetsReceivedOK = value;
-	if (!rtl837x_read_stat_value(port, ifOutOctets, &value))
+	if (!rtl837x_read_ethtool_stat(port, ifOutOctets_H, &value))
 		mac_stats->OctetsTransmittedOK = value;
-	if (!rtl837x_read_stat_value(port, dot3StatsSingleCollisionFrames,
+	if (!rtl837x_read_ethtool_stat(port, dot3StatsSingleCollisionFrames,
 					     &value))
 		mac_stats->SingleCollisionFrames = value;
-	if (!rtl837x_read_stat_value(port, dot3StatMultipleCollisionFrames,
+	if (!rtl837x_read_ethtool_stat(port, dot3StatMultipleCollisionFrames,
 					     &value))
 		mac_stats->MultipleCollisionFrames = value;
-	if (!rtl837x_read_stat_value(port, dot3sDeferredTransmissions, &value))
+	if (!rtl837x_read_ethtool_stat(port, dot3sDeferredTransmissions, &value))
 		mac_stats->FramesWithDeferredXmissions = value;
-	if (!rtl837x_read_stat_value(port, dot3StatsLateCollisions, &value))
+	if (!rtl837x_read_ethtool_stat(port, dot3StatsLateCollisions, &value))
 		mac_stats->LateCollisions = value;
-	if (!rtl837x_read_stat_value(port, dot3StatsExcessiveCollisions,
+	if (!rtl837x_read_ethtool_stat(port, dot3StatsExcessiveCollisions,
 					     &value))
 		mac_stats->FramesAbortedDueToXSColls = value;
 
@@ -812,7 +812,7 @@ static void rtl837x_get_eth_ctrl_stats(struct dsa_switch *ds, int port,
 	if (!rtl837x_valid_port(gsw, port))
 		return;
 
-	if (!rtl837x_read_stat_value(port, dot3ControlInUnknownOpcodes, &value))
+	if (!rtl837x_read_ethtool_stat(port, dot3ControlInUnknownOpcodes, &value))
 		ctrl_stats->UnsupportedOpcodesReceived = value;
 
 	/* Pause frames are already exposed through get_pause_stats(). */
@@ -840,48 +840,48 @@ static void rtl837x_get_rmon_stats(struct dsa_switch *ds, int port,
 	if (!rtl837x_valid_port(gsw, port))
 		return;
 
-	if (!rtl837x_read_stat_value(port, rx_etherStatsUndersizePkts, &value))
+	if (!rtl837x_read_ethtool_stat(port, rx_etherStatsUndersizePkts, &value))
 		rmon_stats->undersize_pkts = value;
-	if (!rtl837x_read_stat_value(port, rx_etherStatsOversizePkts, &value))
+	if (!rtl837x_read_ethtool_stat(port, rx_etherStatsOversizePkts, &value))
 		rmon_stats->oversize_pkts = value;
-	if (!rtl837x_read_stat_value(port, rx_etherStatsFragments, &value))
+	if (!rtl837x_read_ethtool_stat(port, rx_etherStatsFragments, &value))
 		rmon_stats->fragments = value;
-	if (!rtl837x_read_stat_value(port, rx_etherStatsJabbers, &value))
+	if (!rtl837x_read_ethtool_stat(port, rx_etherStatsJabbers, &value))
 		rmon_stats->jabbers = value;
 
-	if (!rtl837x_read_stat_value(port, rx_etherStatsPkts64Octets, &value))
+	if (!rtl837x_read_ethtool_stat(port, rx_etherStatsPkts64Octets, &value))
 		rmon_stats->hist[0] = value;
-	if (!rtl837x_read_stat_value(port, rx_etherStatsPkts65to127Octets,
+	if (!rtl837x_read_ethtool_stat(port, rx_etherStatsPkts65to127Octets,
 					    &value))
 		rmon_stats->hist[1] = value;
-	if (!rtl837x_read_stat_value(port, rx_etherStatsPkts128to255Octets,
+	if (!rtl837x_read_ethtool_stat(port, rx_etherStatsPkts128to255Octets,
 					    &value))
 		rmon_stats->hist[2] = value;
-	if (!rtl837x_read_stat_value(port, rx_etherStatsPkts256to511Octets,
+	if (!rtl837x_read_ethtool_stat(port, rx_etherStatsPkts256to511Octets,
 					    &value))
 		rmon_stats->hist[3] = value;
-	if (!rtl837x_read_stat_value(port, rx_etherStatsPkts512to1023Octets,
+	if (!rtl837x_read_ethtool_stat(port, rx_etherStatsPkts512to1023Octets,
 					    &value))
 		rmon_stats->hist[4] = value;
-	if (!rtl837x_read_stat_value(port, rx_etherStatsPkts1024to1518Octets,
+	if (!rtl837x_read_ethtool_stat(port, rx_etherStatsPkts1024to1518Octets,
 					    &value))
 		rmon_stats->hist[5] = value;
 
-	if (!rtl837x_read_stat_value(port, tx_etherStatsPkts64Octets, &value))
+	if (!rtl837x_read_ethtool_stat(port, tx_etherStatsPkts64Octets, &value))
 		rmon_stats->hist_tx[0] = value;
-	if (!rtl837x_read_stat_value(port, tx_etherStatsPkts65to127Octets,
+	if (!rtl837x_read_ethtool_stat(port, tx_etherStatsPkts65to127Octets,
 					    &value))
 		rmon_stats->hist_tx[1] = value;
-	if (!rtl837x_read_stat_value(port, tx_etherStatsPkts128to255Octets,
+	if (!rtl837x_read_ethtool_stat(port, tx_etherStatsPkts128to255Octets,
 					    &value))
 		rmon_stats->hist_tx[2] = value;
-	if (!rtl837x_read_stat_value(port, tx_etherStatsPkts256to511Octets,
+	if (!rtl837x_read_ethtool_stat(port, tx_etherStatsPkts256to511Octets,
 					    &value))
 		rmon_stats->hist_tx[3] = value;
-	if (!rtl837x_read_stat_value(port, tx_etherStatsPkts512to1023Octets,
+	if (!rtl837x_read_ethtool_stat(port, tx_etherStatsPkts512to1023Octets,
 					    &value))
 		rmon_stats->hist_tx[4] = value;
-	if (!rtl837x_read_stat_value(port, tx_etherStatsPkts1024to1518Octets,
+	if (!rtl837x_read_ethtool_stat(port, tx_etherStatsPkts1024to1518Octets,
 					    &value))
 		rmon_stats->hist_tx[5] = value;
 

--- a/package/kernel/rtl837x/src/rtl837x_dsa_ops.c
+++ b/package/kernel/rtl837x/src/rtl837x_dsa_ops.c
@@ -747,6 +747,19 @@ static void rtl837x_get_pause_stats(struct dsa_switch *ds, int port,
 	pause_stats->tx_pause_frames = rtl837x_read_stat(port, dot3OutPauseFrames);
 }
 
+static void rtl837x_get_eth_phy_stats(struct dsa_switch *ds, int port,
+				      struct ethtool_eth_phy_stats *phy_stats)
+{
+	struct rtk_gsw *gsw = ds->priv;
+	u64 value;
+
+	if (!rtl837x_valid_port(gsw, port))
+		return;
+
+	if (!rtl837x_read_ethtool_stat(port, dot3StatsSymbolErrors, &value))
+		phy_stats->SymbolErrorDuringCarrier = value;
+}
+
 /*
  * RTL8373 exposes the standard packet categories as full-width counters.
  * Read the category counters together so a failed read cannot produce a
@@ -1154,6 +1167,7 @@ static const struct dsa_switch_ops rtl837x_dsa_ops = {
 	.get_ethtool_stats = rtl837x_get_ethtool_stats,
 	.get_sset_count = rtl837x_get_sset_count,
 	.get_pause_stats = rtl837x_get_pause_stats,
+	.get_eth_phy_stats = rtl837x_get_eth_phy_stats,
 	.get_eth_mac_stats = rtl837x_get_eth_mac_stats,
 	.get_eth_ctrl_stats = rtl837x_get_eth_ctrl_stats,
 	.get_rmon_stats = rtl837x_get_rmon_stats,


### PR DESCRIPTION
## Summary

Expose standard Ethernet PHY, MAC, control, and RMON statistics for RTL8373
through the DSA ethtool statistics callbacks.

## Details

- map the existing RTL8373 `dot3StatsSymbolErrors` MIB counter to the standard
  `SymbolErrorDuringCarrier` field;
- report standard packet, octet, collision, deferred-transmission, and
  control-opcode counters;
- map the RTL8373 receive/transmit size histograms to the standard RMON
  ranges;
- leave FCS/alignment fields unset because the chip exposes them as one
  combined counter rather than two exact standard fields;
- leave the 1519-to-maximum bucket unset because this SDK does not expose the
  maximum frame size needed to describe it;
- use the existing RTK/DAL MIB path with the valid paired `_H` identifiers for
  full-width counters.

The PHY symbol-error mapping follows the Linux structured ethtool PHY
statistics field and uses only a counter explicitly exposed by the RTL8373
SDK. No synthetic, inferred, or undocumented PHY metrics are added.

The callbacks return only values that can be represented by the standard
ethtool structures; they do not invent unsupported ranges or split a
combined error counter into duplicate fields.

## Validation

- `git diff --check`: passed.
- `scripts/checkpatch.pl --no-tree --terse`: passed.
- Confirmed `dot3StatsSymbolErrors` is declared by `mib.h` and is the exact
  counter read by the new callback.
- Confirmed Linux 6.18 DSA provides `get_eth_phy_stats` and the upstream
  Realtek RTL8365MB driver maps its symbol-error MIB to
  `SymbolErrorDuringCarrier`.
- Corrected the original MIB references to the identifiers actually declared
  by `mib.h` and made the helper name unique to avoid collision with the
  cached `get_stats64` implementation.
- Full `make package/kernel/rtl837x/compile V=s` was not available on the
  current macOS host because OpenWrt rejects Apple's system `make` as
  unsupported.
- No hardware test was run.

This edits the same DSA operations file as the cached `get_stats64` patch;
the two PRs have only a textual/integration relationship and should be
rebased as needed when #66 is merged.
