### PR TITLE
rtl837x: align and enable link-down FDB age-out

### DIFF
--- a/package/kernel/rtl837x/src/rtk-api/l2.c
+++ b/package/kernel/rtl837x/src/rtk-api/l2.c
@@ -574,9 +574,8 @@ rtk_api_ret_t rtk_l2_table_clearStatus_get(rtk_l2_clearStatus_t *pStatus)
 /* Function Name:
  *      rtk_l2_flushLinkDownPortAddrEnable_set
  * Description:
- *      Set HW flush linkdown port mac configuration of the specified device.
+ *      Set HW flush linkdown port mac configuration.
  * Input:
- *      port - Port id.
  *      enable - link down flush status
  * Output:
  *      None
@@ -584,21 +583,18 @@ rtk_api_ret_t rtk_l2_table_clearStatus_get(rtk_l2_clearStatus_t *pStatus)
  *      RT_ERR_OK           - OK
  *      RT_ERR_FAILED       - Failed
  *      RT_ERR_SMI          - SMI access error
- *      RT_ERR_PORT_ID      - Invalid port number.
  *      RT_ERR_ENABLE       - Invalid enable input.
  * Note:
  *      The status of flush linkdown port address is as following:
  *      - DISABLED
  *      - ENABLED
  */
-rtk_api_ret_t rtk_l2_flushLinkDownPortAddrEnable_set(rtk_port_t port, rtk_enable_t enable)
+rtk_api_ret_t rtk_l2_flushLinkDownPortAddrEnable_set(rtk_enable_t enable)
 {
     rtk_api_ret_t retVal;
 
     if (NULL == RT_MAPPER->l2_flushLinkDownPortAddrEnable_set)
         return RT_ERR_DRIVER_NOT_FOUND;
-	else if (port > RTK_PORT_ID_MAX)
-		return RT_ERR_DRIVER_NOT_FOUND;
 
     RTK_API_LOCK();
     retVal = RT_MAPPER->l2_flushLinkDownPortAddrEnable_set(enable);
@@ -610,29 +606,25 @@ rtk_api_ret_t rtk_l2_flushLinkDownPortAddrEnable_set(rtk_port_t port, rtk_enable
 /* Function Name:
  *      rtk_l2_flushLinkDownPortAddrEnable_get
  * Description:
- *      Get HW flush linkdown port mac configuration of the specified device.
+ *      Get HW flush linkdown port mac configuration.
  * Input:
- *      port - Port id.
  * Output:
  *      pEnable - link down flush status
  * Return:
  *      RT_ERR_OK           - OK
  *      RT_ERR_FAILED       - Failed
  *      RT_ERR_SMI          - SMI access error
- *      RT_ERR_PORT_ID      - Invalid port number.
  * Note:
  *      The status of flush linkdown port address is as following:
  *      - DISABLED
  *      - ENABLED
  */
-rtk_api_ret_t rtk_l2_flushLinkDownPortAddrEnable_get(rtk_port_t port, rtk_enable_t *pEnable)
+rtk_api_ret_t rtk_l2_flushLinkDownPortAddrEnable_get(rtk_enable_t *pEnable)
 {
     rtk_api_ret_t retVal;
 
     if (NULL == RT_MAPPER->l2_flushLinkDownPortAddrEnable_get)
         return RT_ERR_DRIVER_NOT_FOUND;
-	else if (port > RTK_PORT_ID_MAX)
-		return RT_ERR_DRIVER_NOT_FOUND;
 
     RTK_API_LOCK();
     retVal = RT_MAPPER->l2_flushLinkDownPortAddrEnable_get(pEnable);
@@ -2183,4 +2175,3 @@ rtk_api_ret_t rtk_trap_portUnmatchMacPktAction_get(rtk_port_t port, rtk_trap_uca
 
 
 #endif
-

--- a/package/kernel/rtl837x/src/rtk-api/l2.h
+++ b/package/kernel/rtl837x/src/rtk-api/l2.h
@@ -1123,3 +1123,4 @@ extern rtk_api_ret_t rtk_l2_lookupHitIsolationAction_set(rtk_l2_lookupHitIsolati
 extern rtk_api_ret_t rtk_l2_lookupHitIsolationAction_get(rtk_l2_lookupHitIsolationAction_t *pAction);
 
 #endif /* __RTK_API_L2_H__ */
+

--- a/package/kernel/rtl837x/src/rtk-api/l2.h
+++ b/package/kernel/rtl837x/src/rtk-api/l2.h
@@ -517,9 +517,8 @@ extern rtk_api_ret_t rtk_l2_table_clearStatus_get(rtk_l2_clearStatus_t *pStatus)
 /* Function Name:
  *      rtk_l2_flushLinkDownPortAddrEnable_set
  * Description:
- *      Set HW flush linkdown port mac configuration of the specified device.
+ *      Set HW flush linkdown port mac configuration.
  * Input:
- *      port - Port id.
  *      enable - link down flush status
  * Output:
  *      None
@@ -527,34 +526,31 @@ extern rtk_api_ret_t rtk_l2_table_clearStatus_get(rtk_l2_clearStatus_t *pStatus)
  *      RT_ERR_OK           - OK
  *      RT_ERR_FAILED       - Failed
  *      RT_ERR_SMI          - SMI access error
- *      RT_ERR_PORT_ID      - Invalid port number.
  *      RT_ERR_ENABLE       - Invalid enable input.
  * Note:
  *      The status of flush linkdown port address is as following:
  *      - DISABLED
  *      - ENABLED
  */
-extern rtk_api_ret_t rtk_l2_flushLinkDownPortAddrEnable_set(rtk_port_t port, rtk_enable_t enable);
+extern rtk_api_ret_t rtk_l2_flushLinkDownPortAddrEnable_set(rtk_enable_t enable);
 
 /* Function Name:
  *      rtk_l2_flushLinkDownPortAddrEnable_get
  * Description:
- *      Get HW flush linkdown port mac configuration of the specified device.
+ *      Get HW flush linkdown port mac configuration.
  * Input:
- *      port - Port id.
  * Output:
  *      pEnable - link down flush status
  * Return:
  *      RT_ERR_OK           - OK
  *      RT_ERR_FAILED       - Failed
  *      RT_ERR_SMI          - SMI access error
- *      RT_ERR_PORT_ID      - Invalid port number.
  * Note:
  *      The status of flush linkdown port address is as following:
  *      - DISABLED
  *      - ENABLED
  */
-extern rtk_api_ret_t rtk_l2_flushLinkDownPortAddrEnable_get(rtk_port_t port, rtk_enable_t *pEnable);
+extern rtk_api_ret_t rtk_l2_flushLinkDownPortAddrEnable_get(rtk_enable_t *pEnable);
 
 /* Function Name:
  *      rtk_l2_agingEnable_set
@@ -1127,4 +1123,3 @@ extern rtk_api_ret_t rtk_l2_lookupHitIsolationAction_set(rtk_l2_lookupHitIsolati
 extern rtk_api_ret_t rtk_l2_lookupHitIsolationAction_get(rtk_l2_lookupHitIsolationAction_t *pAction);
 
 #endif /* __RTK_API_L2_H__ */
-

--- a/package/kernel/rtl837x/src/rtl837x_dsa_ops.c
+++ b/package/kernel/rtl837x/src/rtl837x_dsa_ops.c
@@ -931,6 +931,11 @@ static int rtl837x_setup(struct dsa_switch *ds)
 			return ret;
 	}
 
+	/* RTL8373 exposes link-down FDB age-out as a chip-global setting. */
+	ret = rtk_l2_flushLinkDownPortAddrEnable_set(ENABLED);
+	if (ret)
+		return rtl837x_to_errno(ret);
+
 	ret = rtk_l2_table_clear();
 	if (ret)
 		return rtl837x_to_errno(ret);


### PR DESCRIPTION
## Summary

Align and enable the RTL8373 chip-global link-down FDB age-out operation.

## Details

The RTL8373 DAL controls one chip-global link-down flush setting and does not
consume a port argument. The RTK wrapper previously accepted a port, rejected
only an out-of-range value, and then discarded it before calling the same
global mapper operation. Remove that misleading argument and update the
wrapper documentation while leaving the DAL implementation and mapper wiring
unchanged.

The switch setup now enables this existing DAL capability once, immediately
after `rtk_l2_init()`, through the corrected global RTK API:
`rtk_l2_flushLinkDownPortAddrEnable_set(ENABLED)`. A setup failure is
propagated. No link-state callback, per-port write, or teardown write is
added; the setting is chip-global and switch reset/reinitialization owns the
hardware state.

## Current-base integration

The branch is rebased directly onto the current `flint3-be9300` tip
`15c0c8175c846576bea17e2aa56354fdc5f6121e`. Merged #63 learning, #64
hairpin, #65 isolation, #66 statistics, #67 ethtool statistics, and #71 FDB
flush-mapper changes are inherited from the base. No duplicate or unrelated
callback changes were added while resolving the rebase.

## Validation

- `git diff --check`: passed.
- `scripts/checkpatch.pl --no-tree --terse`: passed with no output/errors for
  the final diff.
- Final diff is limited to the RTK public wrapper/header signature correction
  and one setup call; the existing DAL implementation and mapper wiring are
  unchanged.
- Verified all RTL837x call sites and DAL prototypes use the new global
  signature.
- A full `make package/kernel/rtl837x/compile V=s` is not available on this
  macOS host because OpenWrt rejects Apple's GNU Make 3.81 before package
  compilation.
- No hardware test was run.

## Dependencies

No hard code dependency remains. This PR is independent of the open bridge,
FDB, policing, and MST work.
