### PR TITLE
rtl837x: add VLAN-specific FDB fast ageing

### DIFF
--- a/package/kernel/rtl837x/src/rtl837x_dsa_ops.c
+++ b/package/kernel/rtl837x/src/rtl837x_dsa_ops.c
@@ -1539,6 +1539,26 @@ static int rtl837x_fdb_vid(u16 vid, struct dsa_db db, u16 *fdb_vid)
 	}
 }
 
+static int rtl837x_port_vlan_fast_age(struct dsa_switch *ds, int port, u16 vid)
+{
+	struct rtk_gsw *gsw = ds->priv;
+	rtk_l2_flushCfg_t cfg = { 0 };
+	rtk_api_ret_t ret;
+
+	if (!rtl837x_user_port(gsw, port) || !vid || vid > RTK_VID_MAX)
+		return -EINVAL;
+
+	cfg.flushByVid = ENABLED;
+	cfg.vid = vid;
+	/* The RTL8373 VID mode uses FLUSH_PMSK as the port restriction. */
+	cfg.portmask = BIT(port);
+	cfg.flushStaticAddr = DISABLED;
+	cfg.flushAddrOnAllPorts = DISABLED;
+
+	ret = rtk_l2_ucastAddr_flush(&cfg);
+	return rtl837x_to_errno(ret);
+}
+
 static int rtl837x_port_vlan_filtering(struct dsa_switch *ds, int port,
 				       bool vlan_filtering,
 				       struct netlink_ext_ack *extack)
@@ -1773,6 +1793,7 @@ static const struct dsa_switch_ops rtl837x_dsa_ops = {
 	.port_bridge_leave = rtl837x_port_bridge_leave,
 	.port_stp_state_set = rtl837x_port_stp_state_set,
 	.port_fast_age = rtl837x_port_fast_age,
+	.port_vlan_fast_age = rtl837x_port_vlan_fast_age,
 	.port_vlan_filtering = rtl837x_port_vlan_filtering,
 	.port_vlan_add = rtl837x_port_vlan_add,
 	.port_vlan_del = rtl837x_port_vlan_del,


### PR DESCRIPTION
## Summary

Add RTL8373 support for DSA VLAN-specific FDB fast ageing.

PR #71, which provides the RTL8373 unicast FDB flush mapper used by the
existing DSA FDB operations, has been merged into `flint3-be9300`. This branch
is rebased onto the current upstream tip
`15c0c8175c846576bea17e2aa56354fdc5f6121e` and contains only the
VLAN-specific fast-age callback.

## Details

Linux DSA uses `port_vlan_fast_age` for VLAN-scoped FDB ageing, including
VLAN/MST-related transitions. This PR adds the callback using the existing
RTK/DAL unicast flush API: it selects VID flush mode, supplies the requested
VID and one physical user-port bit in `FLUSH_PMSK`, and leaves
`flushStaticAddr` disabled so static FDB entries are preserved.

The RTL8373 DAL implementation confirms that the VID and portmask are written
to the hardware flush command. Its `flushAddrOnAllPorts` field is not consumed
by the implementation; this PR does not invent or alter its semantics.

The mapper from merged PR #71 is inherited from the base and is not duplicated
in this diff. This PR does not implement MST support and has no logical
dependency on the other FDB/VLAN PRs.

## Validation

- Rebased cleanly onto current `flint3-be9300`.
- Final diff is one file: 21 additions, no unrelated changes.
- `git diff --check`: passed.
- `scripts/checkpatch.pl --no-tree --terse`: passed.
- Audited the Linux 6.18 DSA callback signature and the RTL8373 RTK wrapper,
  prototype, merged mapper and DAL flush path.
- Local package compilation could not start because the macOS-provided GNU
  make 3.81 is rejected by OpenWrt's prerequisite check.
- No hardware test was run.
