### PR TITLE
rtl837x: expose ASIC identity through devlink info

### DIFF
--- a/package/kernel/rtl837x/src/rtl837x_dsa_ops.c
+++ b/package/kernel/rtl837x/src/rtl837x_dsa_ops.c
@@ -13,6 +13,7 @@
 #include <linux/string.h>
 #include <linux/dsa/8021q.h>
 #include <net/dsa.h>
+#include <net/devlink.h>
 #include <net/switchdev.h>
 
 #include "./rtl837x_common.h"
@@ -22,6 +23,19 @@
 static int rtl837x_to_errno(int ret)
 {
 	return ret == RT_ERR_OK ? 0 : -EIO;
+}
+
+static int rtl837x_devlink_info_get(struct dsa_switch *ds,
+					struct devlink_info_req *req,
+					struct netlink_ext_ack *extack)
+{
+	struct rtk_gsw *gsw = ds->priv;
+
+	if (!gsw->chip_name)
+		return -ENODEV;
+
+	return devlink_info_version_fixed_put(
+		req, DEVLINK_INFO_VERSION_GENERIC_ASIC_ID, gsw->chip_name);
 }
 
 static int rtl837x_mdio_setup(struct dsa_switch *ds);
@@ -1011,6 +1025,7 @@ static int rtl837x_port_fdb_del(struct dsa_switch *ds, int port,
 
 static const struct dsa_switch_ops rtl837x_dsa_ops = {
 	.get_tag_protocol = rtl837x_get_tag_protocol,
+	.devlink_info_get = rtl837x_devlink_info_get,
 	.setup = rtl837x_setup,
 	.teardown = rtl837x_teardown,
 	.phylink_get_caps = rtl837x_phylink_get_caps,


### PR DESCRIPTION
## Summary

Expose the detected RTL837x ASIC identity through the standard DSA devlink
information callback.

## Details

`rtl837x_switch_probe()` already identifies the supported chip and stores its
existing `gsw->chip_name` string before the DSA switch is registered. This PR
publishes that string as `DEVLINK_INFO_VERSION_GENERIC_ASIC_ID` through
`devlink dev info`.

The callback returns `-ENODEV` if the existing chip-name pointer is absent. It
does not add register access, chip probing, or runtime hardware configuration.

This is an independent source-only change based directly on current
`flint3-be9300`.

## Validation

- Rebased directly onto current `upstream/flint3-be9300` at
  `79d086e797e60c0dfb195d4556a5bf5ad1332fc8`.
- Final diff is limited to the standard DSA devlink callback, its include, and
  the `dsa_switch_ops` registration.
- `git diff --check`: passed.
- `scripts/checkpatch.pl --no-tree --terse`: passed.
- Verified the callback signature and devlink helper against the local Linux
  6.18 DSA sources.
- Audited probe ordering to confirm `gsw->chip_name` is assigned before DSA
  registration.
- `make package/kernel/rtl837x/compile V=s` was blocked before compilation:
  OpenWrt rejects Apple's system `make` as unsupported (`Please use a newer
  version of GNU make`).
- No hardware test was performed.
- No successful OpenWrt package build is claimed.
