### PR TITLE
rtl837x: preserve RTK error semantics in DSA callbacks

### DIFF
--- a/package/kernel/rtl837x/src/rtl837x_dsa_ops.c
+++ b/package/kernel/rtl837x/src/rtl837x_dsa_ops.c
@@ -21,7 +21,37 @@
 
 static int rtl837x_to_errno(int ret)
 {
-	return ret == RT_ERR_OK ? 0 : -EIO;
+	/*
+	 * Keep this mapping limited to SDK errors with a direct and stable
+	 * Linux errno meaning.  Unknown and subsystem-specific errors stay
+	 * -EIO rather than being guessed at here.
+	 */
+	switch (ret) {
+	case RT_ERR_OK:
+		return 0;
+	case RT_ERR_INPUT:
+	case RT_ERR_PORT_ID:
+	case RT_ERR_PORT_MASK:
+	case RT_ERR_NULL_POINTER:
+	case RT_ERR_MAC:
+	case RT_ERR_OUT_OF_RANGE:
+	case RT_ERR_ENABLE:
+	case RT_ERR_RANGE:
+	case RT_ERR_VLAN_VID:
+	case RT_ERR_L2_FID:
+	case RT_ERR_L2_VID:
+		return -EINVAL;
+	case RT_ERR_BUSYWAIT_TIMEOUT:
+		return -ETIMEDOUT;
+	case RT_ERR_CHIP_NOT_SUPPORTED:
+	case RT_ERR_DRIVER_NOT_FOUND:
+		return -EOPNOTSUPP;
+	case RT_ERR_L2_NO_EMPTY_ENTRY:
+	case RT_ERR_L2_INDEXTBL_FULL:
+		return -ENOSPC;
+	default:
+		return -EIO;
+	}
 }
 
 static int rtl837x_mdio_setup(struct dsa_switch *ds);


### PR DESCRIPTION
## Summary

Preserve the Linux meaning of a small set of unambiguous RTL837x SDK return
codes at the common DSA error-conversion point.

## Mapping

| RTK error | Linux errno | Reason |
| --- | --- | --- |
| `RT_ERR_OK` | `0` | Success |
| `RT_ERR_INPUT`, `RT_ERR_PORT_ID`, `RT_ERR_PORT_MASK`, `RT_ERR_NULL_POINTER`, `RT_ERR_MAC`, `RT_ERR_OUT_OF_RANGE`, `RT_ERR_ENABLE`, `RT_ERR_RANGE`, `RT_ERR_VLAN_VID`, `RT_ERR_L2_FID`, `RT_ERR_L2_VID` | `-EINVAL` | The SDK documents these as invalid input, port, pointer, MAC, range, enable, VLAN VID, or L2 identifier values |
| `RT_ERR_BUSYWAIT_TIMEOUT` | `-ETIMEDOUT` | Hardware wait timed out |
| `RT_ERR_CHIP_NOT_SUPPORTED`, `RT_ERR_DRIVER_NOT_FOUND` | `-EOPNOTSUPP` | The operation is unsupported or has no registered DAL implementation |
| `RT_ERR_L2_NO_EMPTY_ENTRY`, `RT_ERR_L2_INDEXTBL_FULL` | `-ENOSPC` | The L2 table or hashed index has no available space |

All other RTK values remain `-EIO`. In particular, SMI failures, generic
failures, initialization/state errors, semaphore errors, and
subsystem-specific errors are not guessed at in this central mapper.
`RT_ERR_L2_ENTRY_NOTFOUND` is also intentionally not mapped here: FDB delete
already handles that value as an idempotent success before invoking the
mapper.

## Scope and audit

The change updates only `rtl837x_to_errno()` in
`rtl837x_dsa_ops.c`. All 27 current call sites were audited across EEE,
isolation, VLAN/PVID setup, switch setup, statistics, PHY/MAC operations,
aging, and FDB operations. No callback rewrites, DAL changes, raw register
access, or unrelated cleanup are included.

This is an independent source-only change based directly on current
`flint3-be9300`.

## Validation

- Rebased directly onto current `upstream/flint3-be9300` at
  `79d086e797e60c0dfb195d4556a5bf5ad1332fc8`.
- `git diff --check`: passed.
- `scripts/checkpatch.pl --no-tree --terse`: passed.
- Reviewed the SDK error definitions and return-value documentation for the
  mapped categories.
- `make package/kernel/rtl837x/compile V=s` was blocked before compilation:
  OpenWrt rejects Apple's system `make` as unsupported (`Please use a newer
  version of GNU make`).
- No hardware test was performed.
- No successful OpenWrt package build is claimed.
