### PR TITLE
rtl837x: preserve RTL8373 DAL operation error codes

### DIFF
--- a/package/kernel/rtl837x/src/rtk-api/dal/rtl8373/dal_rtl8373_mirror.c
+++ b/package/kernel/rtl837x/src/rtk-api/dal/rtl8373/dal_rtl8373_mirror.c
@@ -614,8 +614,11 @@ rtk_api_ret_t dal_rtl8373_mirror_sampeRate_set(rtk_uint32 rateVal)
     if(rateVal > MIR_SAMPLE_RATE_MAX)
         return RT_ERR_INPUT;
     
-    if((retVal = rtl8373_setAsicRegBits(RTL8373_MIR_SAMPLE_CRTL_ADDR, RTL8373_MIR_SAMPLE_CRTL_RATE_MASK, rateVal) != RT_ERR_OK))
-           return retVal;
+	retVal = rtl8373_setAsicRegBits(RTL8373_MIR_SAMPLE_CRTL_ADDR,
+					 RTL8373_MIR_SAMPLE_CRTL_RATE_MASK,
+					 rateVal);
+	if (retVal != RT_ERR_OK)
+		return retVal;
     
     return RT_ERR_OK;
 }
@@ -646,8 +649,11 @@ rtk_api_ret_t dal_rtl8373_mirror_sampeRate_get(rtk_uint32 *pRateVal)
     if( pRateVal == NULL)
         return RT_ERR_NULL_POINTER;
     
-    if((retVal = rtl8373_getAsicRegBits(RTL8373_MIR_SAMPLE_CRTL_ADDR, RTL8373_MIR_SAMPLE_CRTL_RATE_MASK, pRateVal) != RT_ERR_OK))
-           return retVal;
+	retVal = rtl8373_getAsicRegBits(RTL8373_MIR_SAMPLE_CRTL_ADDR,
+					 RTL8373_MIR_SAMPLE_CRTL_RATE_MASK,
+					 pRateVal);
+	if (retVal != RT_ERR_OK)
+		return retVal;
     
     return RT_ERR_OK;
 }
@@ -678,8 +684,11 @@ rtk_api_ret_t dal_rtl8373_mirror_pktCnt_get(rtk_uint32 *pCntr)
     if( pCntr == NULL)
         return RT_ERR_NULL_POINTER;
     
-    if((retVal = rtl8373_getAsicRegBits(RTL8373_MIR_MATCHED_ADDR, RTL8373_MIR_MATCHED_PKT_CNT_MASK, pCntr) != RT_ERR_OK))
-           return retVal;
+	retVal = rtl8373_getAsicRegBits(RTL8373_MIR_MATCHED_ADDR,
+					 RTL8373_MIR_MATCHED_PKT_CNT_MASK,
+					 pCntr);
+	if (retVal != RT_ERR_OK)
+		return retVal;
     
     return RT_ERR_OK;
 }
@@ -710,8 +719,11 @@ rtk_api_ret_t dal_rtl8373_mirror_samplePktCnt_get(rtk_uint32 *pCntr)
     if( pCntr == NULL)
         return RT_ERR_NULL_POINTER;
     
-    if((retVal = rtl8373_getAsicRegBits(RTL8373_MIR_MATCHED_ADDR, RTL8373_MIR_MATCHED_SAMPLE_PKT_CNT_MASK, pCntr) != RT_ERR_OK))
-           return retVal;
+	retVal = rtl8373_getAsicRegBits(RTL8373_MIR_MATCHED_ADDR,
+					 RTL8373_MIR_MATCHED_SAMPLE_PKT_CNT_MASK,
+					 pCntr);
+	if (retVal != RT_ERR_OK)
+		return retVal;
     
     return RT_ERR_OK;
 }

--- a/package/kernel/rtl837x/src/rtk-api/dal/rtl8373/dal_rtl8373_phy.c
+++ b/package/kernel/rtl837x/src/rtk-api/dal/rtl8373/dal_rtl8373_phy.c
@@ -155,11 +155,11 @@ rtk_api_ret_t dal_rlt8373_phy_autoNegoAbility_set(rtk_port_t port, rtk_port_phy_
 
     if ((ret = dal_rtl8373_phy_write( 1UL<<port, PHY_MMD_VEND2, 0xA412, phyData)) != RT_ERR_OK)
         return ret;
-    if ((ret = dal_rlt8373_phy_common_c45_an_restart(port) != RT_ERR_OK))
-    {
-    //printf("line %d\n",(uint16)__LINE__);
-    return ret;
-    }
+	ret = dal_rlt8373_phy_common_c45_an_restart(port);
+	if (ret != RT_ERR_OK) {
+		//printf("line %d\n",(uint16)__LINE__);
+		return ret;
+	}
 
     return ret;
 }


### PR DESCRIPTION
## Summary

Preserve RTL8373 DAL error codes in five confirmed C operator-precedence
cases.

## Details

The previous expressions assigned the result of `!= RT_ERR_OK` to the status
variable, so an underlying `RT_ERR_*` value could be collapsed to boolean `1`.
The corrected paths assign the RTK/DAL return value first and compare it
afterwards.

The five fixes cover:

- PHY auto-negotiation restart in `dal_rtl8373_phy.c`;
- mirror sampling-rate set/get in `dal_rtl8373_mirror.c`;
- mirror matched-packet and matched-sampled-packet counter getters in
  `dal_rtl8373_mirror.c`.

Each called function still returns an RTK/DAL status and each caller returns
that status on failure. No hardware operation, register value, return type, or
API semantic was changed.

PR #74 is complementary: it converts selected RTK status values to Linux
errnos at the DSA boundary, while this PR preserves the original status before
that conversion. This PR does not depend on #74.

## Validation

- Rebased onto current `flint3-be9300` (`79d086e797e60c0dfb195d4556a5bf5ad1332fc8`).
- `git diff --check`: passed.
- `scripts/checkpatch.pl --no-tree --terse`: passed with 0 errors and 0 warnings
  for the final patch.
- A source audit found no additional malformed assignment/comparison case of
  the same form in the reviewed RTL8373 DAL paths.
- No package build was completed on this macOS host; OpenWrt requires a Linux
  build environment with supported GNU make.
- No hardware test was performed.
