### PR TITLE
rtl837x: bound RTL8373 VLAN table write polling

### DIFF
--- a/package/kernel/rtl837x/src/rtk-api/dal/rtl8373/dal_rtl8373_vlan.c
+++ b/package/kernel/rtl837x/src/rtk-api/dal/rtl8373/dal_rtl8373_vlan.c
@@ -54,6 +54,7 @@ ret_t _dal_rtl8373_setAsicVlan4kEntry(dal_rtl8373_user_vlan4kentry *pVlan4kEntry
     rtk_uint32  vlanEntryVal = 0;
     rtk_uint32  retVal = 0;
     rtk_uint32  regData = 0;
+	rtk_uint32 busyCounter = 0;
   
     if(pVlan4kEntry->vid > RTL8373_VIDMAX)
         return RT_ERR_VLAN_VID;
@@ -113,10 +114,14 @@ ret_t _dal_rtl8373_setAsicVlan4kEntry(dal_rtl8373_user_vlan4kentry *pVlan4kEntry
 
 
     /*wait access finished */
+	busyCounter = RTL8373_VLAN_BUSY_CHECK_NO;
     do{
         retVal = rtl8373_getAsicReg(RTL8373_ITA_CTRL0_ADDR, &regData);
         if(retVal != RT_ERR_OK)
             return retVal;
+		busyCounter--;
+		if (busyCounter == 0)
+			return RT_ERR_BUSYWAIT_TIMEOUT;
     }while(regData & 0x1);
 
 #if defined(CONFIG_RTL8373_ASICDRV_TEST)


### PR DESCRIPTION
## Summary

Bound RTL8373 VLAN 4K table write polling with the existing DAL timeout
convention.

## Details

The RTL8373 VLAN 4K read path already polls the table busy bit with
`RTL8373_VLAN_BUSY_CHECK_NO` and returns `RT_ERR_BUSYWAIT_TIMEOUT`. The write
path used the same hardware command but polled indefinitely when the busy bit
never cleared.

This PR applies the existing bounded counter to the write-side polling loop.
The VLAN table packing, write command, register addresses, and normal success
path are unchanged. A stuck table access now returns
`RT_ERR_BUSYWAIT_TIMEOUT` to its caller.

PR #74 is only a soft relationship: if merged, its common DSA mapper will
expose this timeout as `-ETIMEDOUT`. This PR is otherwise independent.

## Validation

- Rebased onto current `flint3-be9300` (`79d086e797e60c0dfb195d4556a5bf5ad1332fc8`).
- `git diff --check`: passed.
- `scripts/checkpatch.pl --no-tree --terse`: passed with 0 errors and 0 warnings
  for the final patch.
- Confirmed `RTL8373_VLAN_BUSY_CHECK_NO` is already defined and used by the
  RTL8373 VLAN read polling paths.
- Confirmed the write command and VLAN entry packing are unchanged.
- No package build was completed on this macOS host; OpenWrt requires a Linux
  build environment with supported GNU make.
- No hardware test was performed.
