### PR TITLE
rtl837x: fix RTL8373 PHY poll termination

### DIFF
--- a/package/kernel/rtl837x/src/rtk-api/dal/rtl8373/dal_rtl8373_switch.c
+++ b/package/kernel/rtl837x/src/rtk-api/dal/rtl8373/dal_rtl8373_switch.c
@@ -1953,7 +1953,7 @@ void RL6818C_pwr_on_patch_phy_v008_rls_lockmain(rtk_uint32 phymask)
         {
             dal_rtl8373_phy_regbits_read(port, 31, 0xa600, 0xff, &pcs_state);
             counter--;
-        } while (!(pcs_state == 1 || counter == 0));
+		} while (!(pcs_state == 1 || counter == 0));
 
         dal_rtl8373_phy_regbits_write(1 << port, 31, 0xa436, 0xffff, 0x801e);
 
@@ -2012,7 +2012,7 @@ void RL6818C_pwr_on_patch_phy_v008(rtk_uint32 phymask)
                 dal_rtl8373_phy_regbits_read(port, 31, 0xb800, 1 << 6, &patch_rdy);
                 delay_loop(10);
                 counter--;
-            } while (!(patch_rdy == 1 || counter == 0));
+			} while (!(patch_rdy == 1 || counter == 0));
 
             // # Set patch_key & patch_lock
             dal_rtl8373_phy_regbits_write(1 << port, 31, 0xa436, 0xffff, patch_key_addr);
@@ -2065,7 +2065,7 @@ void RL6818C_pwr_on_patch_phy_v008(rtk_uint32 phymask)
             delay_loop(10);
             dal_rtl8373_phy_regbits_read(port, 31, 0xb800, 1 << 6, &patch_rdy);
             counter--;
-        } while (!(patch_rdy == 0 || counter == 0));
+		} while (!(patch_rdy == 0 || counter == 0));
 
         // ## Lock Main
         dal_rtl8373_phy_regbits_write(1 << port, 31, 0xa4a0, 1 << 10, 1);
@@ -2076,7 +2076,7 @@ void RL6818C_pwr_on_patch_phy_v008(rtk_uint32 phymask)
             delay_loop(10);
             dal_rtl8373_phy_regbits_read(port, 31, 0xa600, 0xff, &pcs_state);
             counter--;
-        } while (!(pcs_state == 1 || counter == 0));
+		} while (!(pcs_state == 1 || counter == 0));
 
         // RTCT patch
 

--- a/package/kernel/rtl837x/src/rtk-api/dal/rtl8373/dal_rtl8373_switch.c
+++ b/package/kernel/rtl837x/src/rtk-api/dal/rtl8373/dal_rtl8373_switch.c
@@ -1953,7 +1953,7 @@ void RL6818C_pwr_on_patch_phy_v008_rls_lockmain(rtk_uint32 phymask)
         {
             dal_rtl8373_phy_regbits_read(port, 31, 0xa600, 0xff, &pcs_state);
             counter--;
-        } while (pcs_state == 1 || counter == 0);
+        } while (!(pcs_state == 1 || counter == 0));
 
         dal_rtl8373_phy_regbits_write(1 << port, 31, 0xa436, 0xffff, 0x801e);
 
@@ -2012,7 +2012,7 @@ void RL6818C_pwr_on_patch_phy_v008(rtk_uint32 phymask)
                 dal_rtl8373_phy_regbits_read(port, 31, 0xb800, 1 << 6, &patch_rdy);
                 delay_loop(10);
                 counter--;
-            } while (patch_rdy != 1 || counter == 0);
+            } while (!(patch_rdy == 1 || counter == 0));
 
             // # Set patch_key & patch_lock
             dal_rtl8373_phy_regbits_write(1 << port, 31, 0xa436, 0xffff, patch_key_addr);
@@ -2065,7 +2065,7 @@ void RL6818C_pwr_on_patch_phy_v008(rtk_uint32 phymask)
             delay_loop(10);
             dal_rtl8373_phy_regbits_read(port, 31, 0xb800, 1 << 6, &patch_rdy);
             counter--;
-        } while (patch_rdy != 0 || counter == 0);
+        } while (!(patch_rdy == 0 || counter == 0));
 
         // ## Lock Main
         dal_rtl8373_phy_regbits_write(1 << port, 31, 0xa4a0, 1 << 10, 1);
@@ -2076,7 +2076,7 @@ void RL6818C_pwr_on_patch_phy_v008(rtk_uint32 phymask)
             delay_loop(10);
             dal_rtl8373_phy_regbits_read(port, 31, 0xa600, 0xff, &pcs_state);
             counter--;
-        } while (pcs_state != 1 || counter == 0);
+        } while (!(pcs_state == 1 || counter == 0));
 
         // RTCT patch
 


### PR DESCRIPTION
## Summary

Fix the termination conditions of four RTL8373 PHY patch polling loops.

## Problem

The RTL6818C PHY patch path initializes a 30-iteration counter, but four
polling loops used conditions of the form `expected_state || counter == 0`.
That is inverted for a do/while termination test: the loop could continue
after the counter reached zero while the expected state remained true, and it
could leave early while the hardware was still in the wrong state. Since the
counter is unsigned, the former case could wrap and spin indefinitely.

The affected waits are the C-revision equivalents of the neighbouring
RTL6818B waits in the same file:

- PCS ready after releasing the main lock;
- patch-ready assertion;
- patch-ready deassertion;
- PCS ready after reacquiring the main lock.

## Fix

Use the existing bounded termination form, `!(expected_state ||
counter == 0)`, for all four loops. This preserves the existing 30-poll
limit and makes the C-revision path consistent with the already-correct B
revision implementation. No PHY register programming or timeout value was
otherwise changed.

## Current-base integration

The branch is rebased directly onto current `flint3-be9300` at
`15c0c8175c846576bea17e2aa56354fdc5f6121e`, including merged #63, #64, #65,
#66, #67, and #71. The final diff remains one file with four condition-only
changes.

## Validation

- `git diff --check`: passed.
- `scripts/checkpatch.pl --no-tree --terse`: passed with no output/errors.
- `make package/kernel/rtl837x/compile V=s`: unavailable on this macOS host;
  OpenWrt stops before compilation because Apple's GNU Make 3.81 is not
  supported.
- No hardware test was run.
